### PR TITLE
Add support for StreamDeck XL, new StreamDeck Original V2 variants.

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ sudo tee /etc/udev/rules.d/99-streamdeck.rules << EOF
 SUBSYSTEM=="usb", ATTRS{idVendor}=="0fd9", ATTRS{idProduct}=="0060", MODE:="666", GROUP="plugdev"
 SUBSYSTEM=="usb", ATTRS{idVendor}=="0fd9", ATTRS{idProduct}=="0063", MODE:="666", GROUP="plugdev"
 SUBSYSTEM=="usb", ATTRS{idVendor}=="0fd9", ATTRS{idProduct}=="006c", MODE:="666", GROUP="plugdev"
+SUBSYSTEM=="usb", ATTRS{idVendor}=="0fd9", ATTRS{idProduct}=="006d", MODE:="666", GROUP="plugdev"
 EOF
 
 sudo udevadm control --reload-rules

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ readme = "README.md"
 
 [tool.poetry.dependencies]
 python = "^3.6"
-streamdeck = "^0.5.0"
+streamdeck = "^0.6.3"
 pillow = "^6.1"
 hidapi = "^0.7.99"
 pynput = "^1.4"


### PR DESCRIPTION
Fixes #3, where the StreamDeck XL fails to work due to a bug in the upstream StreamDeck library dependency.

Also updates the docs for the StreamDeck Original V2 hardware variant that is now being sold, support for which was also recently added into the StreamDeck library.