### PR TITLE
Use shlex for correct tokenization of command line args

### DIFF
--- a/streamdeck_ui/api.py
+++ b/streamdeck_ui/api.py
@@ -3,6 +3,7 @@ import json
 import os
 import threading
 from functools import partial
+import shlex
 from subprocess import Popen  # nosec - Need to allow users to specify arbitrary commands
 from typing import Dict, List, Tuple, Union
 from warnings import warn
@@ -27,7 +28,7 @@ def _key_change_callback(deck_id: str, _deck: StreamDeck.StreamDeck, key: int, s
 
         command = get_button_command(deck_id, page, key)
         if command:
-            Popen(command.split(" "))
+            Popen(shlex.split(command))
 
         keys = get_button_keys(deck_id, page, key)
         if keys:


### PR DESCRIPTION
Complex command line arguments don't work properly with splitting on spaces for Popen. The  [official Python documentation](https://docs.python.org/3/library/subprocess.html#popen-constructor) recommends shlex. 