### PR TITLE
Added missing udev lines to Ubuntu and Fedora install scripts

### DIFF
--- a/scripts/fedora_install.sh
+++ b/scripts/fedora_install.sh
@@ -8,6 +8,7 @@ sudo tee /etc/udev/rules.d/99-streamdeck.rules << EOF
 SUBSYSTEM=="usb", ATTRS{idVendor}=="0fd9", ATTRS{idProduct}=="0060", MODE:="666", GROUP="plugdev"
 SUBSYSTEM=="usb", ATTRS{idVendor}=="0fd9", ATTRS{idProduct}=="0063", MODE:="666", GROUP="plugdev"
 SUBSYSTEM=="usb", ATTRS{idVendor}=="0fd9", ATTRS{idProduct}=="006c", MODE:="666", GROUP="plugdev"
+SUBSYSTEM=="usb", ATTRS{idVendor}=="0fd9", ATTRS{idProduct}=="006d", MODE:="666", GROUP="plugdev"
 EOF
 
 sudo udevadm control --reload-rules

--- a/scripts/ubuntu_install.sh
+++ b/scripts/ubuntu_install.sh
@@ -8,6 +8,7 @@ sudo tee /etc/udev/rules.d/99-streamdeck.rules << EOF
 SUBSYSTEM=="usb", ATTRS{idVendor}=="0fd9", ATTRS{idProduct}=="0060", MODE:="666", GROUP="plugdev"
 SUBSYSTEM=="usb", ATTRS{idVendor}=="0fd9", ATTRS{idProduct}=="0063", MODE:="666", GROUP="plugdev"
 SUBSYSTEM=="usb", ATTRS{idVendor}=="0fd9", ATTRS{idProduct}=="006c", MODE:="666", GROUP="plugdev"
+SUBSYSTEM=="usb", ATTRS{idVendor}=="0fd9", ATTRS{idProduct}=="006d", MODE:="666", GROUP="plugdev"
 EOF
 
 sudo udevadm control --reload-rules


### PR DESCRIPTION
Hello, 
these udev lines were missing from the install script and in my case were needed. 