### PR TITLE
Fix links to debian/ubuntu and fedora scripts.

### DIFF
--- a/index.html
+++ b/index.html
@@ -595,7 +595,7 @@
 <p>Communication with the Streamdeck is powered by the <a href="https://github.com/abcminiuser/python-elgato-streamdeck#python-elgato-stream-deck-library">Python Elgato Stream Deck Library</a>.</p>
 <h2 id="linux-quick-start">Linux Quick Start</h2>
 <h3 id="precooked-scripts">Precooked Scripts</h3>
-<p>There are scripts for setting up streamdeck_ui on <a href="scripts/ubuntu_install.sh">Debian/Ubuntu</a> and <a href="scripts/fedora_install.sh">Fedora</a>.</p>
+<p>There are scripts for setting up streamdeck_ui on <a href="https://raw.githubusercontent.com/timothycrosley/streamdeck-ui/master/scripts/ubuntu_install.sh">Debian/Ubuntu</a> and <a href="https://raw.githubusercontent.com/timothycrosley/streamdeck-ui/master/scripts/fedora_install.sh">Fedora</a>.</p>
 <h3 id="manual-installation">Manual installation</h3>
 <p>To use streamdeck_ui on Linux, you will need first to install some pre-requisite system libraries.
 The name of those libraries will differ depending on your Operating System.<br />


### PR DESCRIPTION
Code was using relative links referencing a file in the repo not linking to the repo (script isn't in the gh-pages branch).