### PR TITLE
Update Fedora Install Docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ sudo apt-get install libhidapi-hidraw0 libudev-dev libusb-1.0-0-dev python3-pip
 ```
 Fedora:
 ```bash
-sudo dnf install python3-devel libusb-devel python3-pip
+sudo dnf install python3-devel libusb-devel python3-pip libusbx-devel libudev-devel
 ```
 If you're using GNOME shell, you might need to manually install an extension that adds [KStatusNotifierItem/AppIndicator Support](https://extensions.gnome.org/extension/615/appindicator-support/) to make the tray icon show up.
 

--- a/scripts/fedora_install.sh
+++ b/scripts/fedora_install.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -xe
 echo "Installing libraries"
-sudo dnf install python3-devel libusb-devel
+sudo dnf install python3-devel libusb-devel libusbx-devel libudev-devel
 echo "Adding udev rules and reloading"
 sudo usermod -a -G plugdev `whoami`
 


### PR DESCRIPTION
These libs are needed in fedora 31+ to install hipadpi as part of the pip install.

Add libusbx-devel libudev-devel to install script
Add libusbx-devel libudev-devel to main read me docs