### PR TITLE
README suggestions

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,8 +51,10 @@ Add your user to the 'plugdev' group:
 ```bash
 sudo usermod -a -G plugdev `whoami`
 ```
-Add the udev rules using your favorite text editor:
+Add the udev rules using your text editor:
 ```bash
+sudoedit /etc/udev/rules.d/99-streamdeck.rules
+# If that doesn't work, try:
 sudo nano /etc/udev/rules.d/99-streamdeck.rules
 ```
 Paste the following lines:

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ To use streamdeck_ui on Linux, you will need first to install some pre-requisite
 The name of those libraries will differ depending on your Operating System.  
 Debian / Ubuntu:
 ```bash
-sudo apt-get install libhidapi-hidraw0 libudev-dev libusb-1.0-0-dev python3-pip
+sudo apt install libhidapi-hidraw0 libudev-dev libusb-1.0-0-dev python3-pip
 ```
 Fedora:
 ```bash


### PR DESCRIPTION
- Recommend `apt` rather than `apt-get`; for interactive use, it's more user friendly.
- Suggest `sudoedit` as a way of editing a file that needs superuser access. The reader gets to use their default editor along with their usual settings.

`sudo` and recent macOS don't play well with each other, though, so I've left in the old command as a fallback.