### PR TITLE
Ensure ubuntu script installs python3-pip (#1)

### DIFF
--- a/scripts/ubuntu_install.sh
+++ b/scripts/ubuntu_install.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -xe
 echo "Installing libraries"
-sudo apt install libhidapi-hidraw0 libudev-dev libusb-1.0-0-dev
+sudo apt install libhidapi-hidraw0 libudev-dev libusb-1.0-0-dev python3-pip
 echo "Adding udev rules and reloading"
 sudo usermod -a -G plugdev `whoami`
 


### PR DESCRIPTION
Python3-pip is not installed by default on ubuntu 20.04, from what I could tell