### PR TITLE
Fix for 404 on Gitter link

### DIFF
--- a/docs/contributing/1.-contributing-guide.md
+++ b/docs/contributing/1.-contributing-guide.md
@@ -32,7 +32,7 @@ Congrats! You're now ready to make a contribution! Use the following as a guide 
 1. Check the [issues page](https://github.com/timothycrosley/streamdeck_ui/issues) on GitHub to see if the task you want to complete is listed there.
     - If it's listed there, write a comment letting others know you are working on it.
     - If it's not listed in GitHub issues, go ahead and log a new issue. Then add a comment letting everyone know you have it under control.
-        - If you're not sure if it's something that is good for the main streamdeck_ui project and want immediate feedback, you can discuss it [here](https://gitter.im/timothycrosley/streamdeck_ui).
+        - If you're not sure if it's something that is good for the main streamdeck_ui project and want immediate feedback, you can discuss it [here](https://gitter.im/timothycrosley/streamdeck-ui).
 2. Create an issue branch for your local work `git checkout -b issue/$ISSUE-NUMBER`.
 3. Do your magic here.
 4. Ensure your code matches the [HOPE-8 Coding Standard](https://github.com/hugapi/HOPE/blob/master/all/HOPE-8--Style-Guide-for-Hug-Code.md#hope-8----style-guide-for-hug-code) used by the project.


### PR DESCRIPTION
The Gitter link had the wrong URL, but I managed to guess the correct one :+1: