### PR TITLE
Add QT5 dependency to ubuntu script

### DIFF
--- a/scripts/ubuntu_install.sh
+++ b/scripts/ubuntu_install.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -xe
 echo "Installing libraries"
-sudo apt install libhidapi-hidraw0 libudev-dev libusb-1.0-0-dev
+sudo apt install qt5-default libhidapi-hidraw0 libudev-dev libusb-1.0-0-dev
 echo "Adding udev rules and reloading"
 sudo usermod -a -G plugdev `whoami`
 


### PR DESCRIPTION
By default, Ubuntu 20.04 doesn't come with QT5. The installation will not fail but starting the application produces an error.

```
qt.qpa.plugin: Could not load the Qt platform plugin "xcb" in "" even though it was found.
This application failed to start because no Qt platform plugin could be initialized. Reinstalling the application may fix this problem.

Available platform plugins are: eglfs, linuxfb, minimal, minimalegl, offscreen, vnc, wayland-egl, wayland, wayland-xcomposite-egl, wayland-xcomposite-glx, webgl, xcb.

Aborted (core dumped)
```