### PR TITLE
#72 Add Clock Display Functionality

### DIFF
--- a/streamdeck_ui/api.py
+++ b/streamdeck_ui/api.py
@@ -142,7 +142,7 @@ def _button_state(deck_id: str, page: int, button: int) -> dict:
 
 
 def set_button_live_time(deck_id: str, page: int, button: int, start: bool) -> None:
-    """Set the button to display live time every second, based on results from the given function"""
+    """Set the button to display live time every second"""
     import threading
 
     # Ensure we don't kick off multiple threads at once
@@ -170,6 +170,76 @@ def _run_live_time(thread_name: str, deck_id: str, page: int, button: int) -> No
 
     while thread_status[thread_name]:
         result = datetime.now().strftime("%H:%M:%S")
+        set_button_text(deck_id, page, button, result)
+
+        time.sleep(1)
+
+
+def set_button_live_hour(deck_id: str, page: int, button: int, start: bool) -> None:
+    """Set the button to display the current hour"""
+    import threading
+
+    # Ensure we don't kick off multiple threads at once
+    thread_name = f"{deck_id}-{page}-{button}-hour"
+
+    # Check to see if this thread is already running
+    if any(thread.name == thread_name for thread in threading.enumerate()):
+        if not start:
+            # Kill the thread via flag
+            thread_status[thread_name] = False
+
+            # Clear Text
+            set_button_text(deck_id, page, button, "")
+        return
+
+    thread_status[thread_name] = True
+    thread = threading.Thread(name=thread_name, target=_run_live_hour, args=(thread_name, deck_id, page, button))
+    thread.daemon = True
+    thread.start()
+
+
+def _run_live_hour(thread_name: str, deck_id: str, page: int, button: int) -> None:
+    from datetime import datetime
+    import time
+
+    while thread_status[thread_name]:
+        result = datetime.now().strftime("%H")
+        set_button_text(deck_id, page, button, result)
+
+        time.sleep(1)
+
+
+def set_button_live_minute(deck_id: str, page: int, button: int, start: bool) -> None:
+    """Set the button to display the current minute"""
+    import threading
+
+    # Ensure we don't kick off multiple threads at once
+    btn_prefix = f"{deck_id}-{page}-{button}"
+    thread_name = f"{btn_prefix}-minute"
+
+    # Check to see if this thread is already running
+    if any(thread.name.startswith(btn_prefix) for thread in threading.enumerate()):
+        # Kill the thread via flag
+        thread_status[thread_name] = False
+
+        # Clear Text
+        set_button_text(deck_id, page, button, "")
+
+        if not start:
+            return
+
+    thread_status[thread_name] = True
+    thread = threading.Thread(name=thread_name, target=_run_live_minute, args=(thread_name, deck_id, page, button))
+    thread.daemon = True
+    thread.start()
+
+
+def _run_live_minute(thread_name: str, deck_id: str, page: int, button: int) -> None:
+    from datetime import datetime
+    import time
+
+    while thread_status[thread_name]:
+        result = datetime.now().strftime("%M")
         set_button_text(deck_id, page, button, result)
 
         time.sleep(1)

--- a/streamdeck_ui/api.py
+++ b/streamdeck_ui/api.py
@@ -184,11 +184,10 @@ class LiveFunction:
             live_functions.remove(lf)
 
 
-def set_button_live_time(deck_id: str, page: int, button: int, start: bool) -> None:
-    """Set the button to display live time every second"""
+def _set_button_live_info(deck_id: str, page: int, button: int, start: bool, func, *args):
     import threading
 
-    live_function = LiveFunction(deck_id, page, button, _get_current_time, ["%H:%M:%S"])
+    live_function = LiveFunction(deck_id, page, button, func, *args)
 
     if not start:
         live_function.remove_all_from_btn()
@@ -213,90 +212,24 @@ def set_button_live_time(deck_id: str, page: int, button: int, start: bool) -> N
     thread.start()
 
 
+def set_button_live_time(deck_id: str, page: int, button: int, start: bool) -> None:
+    """Set the button to display live time every second"""
+    _set_button_live_info(deck_id, page, button, start, _get_current_time, ["%H:%M:%S"])
+
+
 def _get_current_time(date_format: str):
     from datetime import datetime
     return datetime.now().strftime(date_format)
 
 
-def _run_live_time(thread_name: str, deck_id: str, page: int, button: int) -> None:
-    from datetime import datetime
-    import time
-
-    while thread_status[thread_name]:
-        result = datetime.now().strftime("%H:%M:%S")
-        set_button_info(deck_id, page, button, result)
-
-        time.sleep(1)
-
-
 def set_button_live_hour(deck_id: str, page: int, button: int, start: bool) -> None:
     """Set the button to display the current hour"""
-    import threading
-
-    # Ensure we don't kick off multiple threads at once
-    thread_name = f"{deck_id}-{page}-{button}-hour"
-
-    # Check to see if this thread is already running
-    if any(thread.name == thread_name for thread in threading.enumerate()):
-        if not start:
-            # Kill the thread via flag
-            thread_status[thread_name] = False
-
-            # Clear Text
-            set_button_text(deck_id, page, button, "")
-        return
-
-    thread_status[thread_name] = True
-    thread = threading.Thread(name=thread_name, target=_run_live_hour, args=(thread_name, deck_id, page, button))
-    thread.daemon = True
-    thread.start()
-
-
-def _run_live_hour(thread_name: str, deck_id: str, page: int, button: int) -> None:
-    from datetime import datetime
-    import time
-
-    while thread_status[thread_name]:
-        result = datetime.now().strftime("%H")
-        set_button_text(deck_id, page, button, result)
-
-        time.sleep(1)
+    _set_button_live_info(deck_id, page, button, start, _get_current_time, ["%H"])
 
 
 def set_button_live_minute(deck_id: str, page: int, button: int, start: bool) -> None:
     """Set the button to display the current minute"""
-    import threading
-
-    # Ensure we don't kick off multiple threads at once
-    btn_prefix = f"{deck_id}-{page}-{button}"
-    thread_name = f"{btn_prefix}-minute"
-
-    # Check to see if this thread is already running
-    if any(thread.name.startswith(btn_prefix) for thread in threading.enumerate()):
-        # Kill the thread via flag
-        thread_status[thread_name] = False
-
-        # Clear Text
-        set_button_text(deck_id, page, button, "")
-
-        if not start:
-            return
-
-    thread_status[thread_name] = True
-    thread = threading.Thread(name=thread_name, target=_run_live_minute, args=(thread_name, deck_id, page, button))
-    thread.daemon = True
-    thread.start()
-
-
-def _run_live_minute(thread_name: str, deck_id: str, page: int, button: int) -> None:
-    from datetime import datetime
-    import time
-
-    while thread_status[thread_name]:
-        result = datetime.now().strftime("%M")
-        set_button_text(deck_id, page, button, result)
-
-        time.sleep(1)
+    _set_button_live_info(deck_id, page, button, start, _get_current_time, ["%M"])
 
 
 def _start_live_updater():

--- a/streamdeck_ui/api.py
+++ b/streamdeck_ui/api.py
@@ -183,6 +183,9 @@ class LiveFunction:
         for lf in lf_to_remove:
             live_functions.remove(lf)
 
+    def btn_has_diff_function_running(self):
+        return any(self.deck_id == f.deck_id and self.page == f.page and self.button == f.button and (self.function != f.function or self.function_args != f.function_args) for f in live_functions)
+
 
 def _set_button_live_info(deck_id: str, page: int, button: int, start: bool, func, *args):
     import threading
@@ -195,6 +198,9 @@ def _set_button_live_info(deck_id: str, page: int, button: int, start: bool, fun
         # Clear Text
         set_button_info(deck_id, page, button, "")
         return
+
+    if live_function.btn_has_diff_function_running():
+        live_function.remove_all_from_btn()
 
     # Already registered, skip and carry on
     if live_function in live_functions:

--- a/streamdeck_ui/api.py
+++ b/streamdeck_ui/api.py
@@ -19,7 +19,7 @@ image_cache: Dict[str, memoryview] = {}
 decks: Dict[str, StreamDeck.StreamDeck] = {}
 state: Dict[str, Dict[str, Union[int, Dict[int, Dict[int, Dict[str, str]]]]]] = {}
 
-thread_status = {}
+live_functions: List = []
 
 
 def _key_change_callback(deck_id: str, _deck: StreamDeck.StreamDeck, key: int, state: bool) -> None:
@@ -139,9 +139,6 @@ def _button_state(deck_id: str, page: int, button: int) -> dict:
     buttons = state.setdefault(deck_id, {}).setdefault("buttons", {})
     buttons_state = buttons.setdefault(page, {})  # type: ignore
     return buttons_state.setdefault(button, {})  # type: ignore
-
-
-live_functions = []
 
 
 class LiveFunction:

--- a/streamdeck_ui/api.py
+++ b/streamdeck_ui/api.py
@@ -230,11 +230,14 @@ def _get_current_time(date_format: str):
 
 def set_button_live_hour(deck_id: str, page: int, button: int, start: bool) -> None:
     """Set the button to display the current hour"""
+    # Set Font
+    _button_state(deck_id, page, button)["font_size"] = 48
     _set_button_live_info(deck_id, page, button, start, _get_current_time, ["%H"])
 
 
 def set_button_live_minute(deck_id: str, page: int, button: int, start: bool) -> None:
     """Set the button to display the current minute"""
+    _button_state(deck_id, page, button)["font_size"] = 48
     _set_button_live_info(deck_id, page, button, start, _get_current_time, ["%M"])
 
 
@@ -410,6 +413,8 @@ def _render_key_image(deck, icon: str = "", text: str = "", information: str = "
     image = ImageHelpers.PILHelper.create_image(deck)
     draw = ImageDraw.Draw(image)
 
+    font_size = kwargs.get("font_size") if kwargs.get("font_size") else 14
+
     # Give information priority over text
     if information:
         text = information
@@ -428,12 +433,12 @@ def _render_key_image(deck, icon: str = "", text: str = "", information: str = "
     image.paste(rgba_icon, icon_pos, rgba_icon)
 
     if text:
-        true_font = ImageFont.truetype(os.path.join(FONTS_PATH, font), 14)
+        true_font = ImageFont.truetype(os.path.join(FONTS_PATH, font), font_size)
         label_w, label_h = draw.textsize(text, font=true_font)
         if icon:
             label_pos = ((image.width - label_w) // 2, image.height - 20)
         else:
-            label_pos = ((image.width - label_w) // 2, (image.height // 2) - 7)
+            label_pos = ((image.width - label_w) // 2, ((image.height - label_h) // 2))
         draw.text(label_pos, text=text, font=true_font, fill="white")
 
     return ImageHelpers.PILHelper.to_native_format(deck, image)

--- a/streamdeck_ui/gui.py
+++ b/streamdeck_ui/gui.py
@@ -113,7 +113,14 @@ def set_information(ui, index: int, button=None) -> None:
     api.set_button_information_index(deck_id, _page(ui), button.index, index)
 
     if index == 1:
+        # Current Time (H:M:S)
         api.set_button_live_time(deck_id, _page(ui), button.index, True)
+    elif index == 2:
+        # Current Time (H)
+        api.set_button_live_hour(deck_id, _page(ui), button.index, True)
+    elif index == 3:
+        # Current Time (M)
+        api.set_button_live_minute(deck_id, _page(ui), button.index, True)
     else:
         api.set_button_live_time(deck_id, _page(ui), button.index, False)
 

--- a/streamdeck_ui/gui.py
+++ b/streamdeck_ui/gui.py
@@ -97,6 +97,12 @@ def redraw_buttons(ui) -> None:
     current_tab = ui.pages.currentWidget()
     buttons = current_tab.findChildren(QtWidgets.QToolButton)
     for button in buttons:
+        # Give "info" priority
+        info = api.get_button_info(deck_id, _page(ui), button.index)
+        if info:
+            button.setText(info)
+            continue
+
         button.setText(api.get_button_text(deck_id, _page(ui), button.index))
         button.setIcon(QIcon(api.get_button_icon(deck_id, _page(ui), button.index)))
 
@@ -110,6 +116,10 @@ def set_information(ui, index: int, button=None) -> None:
     if not button:
         button = selected_button
     deck_id = _deck_id(ui)
+    prev_information_index = api.get_button_information_index(deck_id, _page(ui), button.index)
+    if prev_information_index == index:
+        return
+
     api.set_button_information_index(deck_id, _page(ui), button.index, index)
 
     if index == 1:
@@ -138,13 +148,20 @@ def button_clicked(ui, clicked_button, buttons) -> None:
 
     deck_id = _deck_id(ui)
     button_id = selected_button.index
-    ui.text.setText(api.get_button_text(deck_id, _page(ui), button_id))
+    text = api.get_button_text(deck_id, _page(ui), button_id)
+    ui.text.setText(text)
     ui.command.setText(api.get_button_command(deck_id, _page(ui), button_id))
     ui.keys.setText(api.get_button_keys(deck_id, _page(ui), button_id))
     ui.write.setPlainText(api.get_button_write(deck_id, _page(ui), button_id))
     ui.change_brightness.setValue(api.get_button_change_brightness(deck_id, _page(ui), button_id))
     ui.switch_page.setValue(api.get_button_switch_page(deck_id, _page(ui), button_id))
-    ui.information.setCurrentIndex(api.get_button_information_index(deck_id, _page(ui), button_id))
+
+    info_index = api.get_button_information_index(deck_id, _page(ui), button_id)
+    if info_index == 0:
+        api.set_button_info(deck_id, _page(ui), button_id, "")
+    ui.information.setCurrentIndex(info_index)
+
+    redraw_buttons(ui)
 
 
 def build_buttons(ui, tab) -> None:

--- a/streamdeck_ui/gui.py
+++ b/streamdeck_ui/gui.py
@@ -1,5 +1,4 @@
 """Defines the QT powered interface for configuring Stream Decks"""
-from datetime import datetime
 import os
 import sys
 from functools import partial

--- a/streamdeck_ui/gui.py
+++ b/streamdeck_ui/gui.py
@@ -112,12 +112,12 @@ def set_brightness(ui, value: int) -> None:
     api.set_brightness(deck_id, value)
 
 
-def set_information(ui, index: int, button=None) -> None:
+def set_information(ui, index: int, button=None, build: bool=False) -> None:
     if not button:
         button = selected_button
     deck_id = _deck_id(ui)
     prev_information_index = api.get_button_information_index(deck_id, _page(ui), button.index)
-    if prev_information_index == index:
+    if prev_information_index == index and not build:
         return
 
     api.set_button_information_index(deck_id, _page(ui), button.index, index)
@@ -202,7 +202,7 @@ def build_buttons(ui, tab) -> None:
 
         info_index = api.get_button_information_index(deck_id, _page(ui), button.index)
         if info_index != 0:
-            set_information(ui, info_index, button)
+            set_information(ui, info_index, button, build=True)
 
     redraw_buttons(ui)
     tab.hide()

--- a/streamdeck_ui/main.ui
+++ b/streamdeck_ui/main.ui
@@ -294,6 +294,16 @@
                  <string>Current Time (H:M:S)</string>
                 </property>
                </item>
+               <item>
+                <property name="text">
+                 <string>Current Time (H)</string>
+                </property>
+               </item>
+               <item>
+                <property name="text">
+                 <string>Current Time (M)</string>
+                </property>
+               </item>
               </widget>
              </item>
             </layout>

--- a/streamdeck_ui/main.ui
+++ b/streamdeck_ui/main.ui
@@ -56,6 +56,19 @@
          </widget>
         </item>
         <item>
+         <widget class="QLabel" name="label_9">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="text">
+           <string>Information:</string>
+          </property>
+         </widget>
+        </item>
+        <item>
          <widget class="QSlider" name="brightness">
           <property name="sizePolicy">
            <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
@@ -218,14 +231,14 @@
              <item row="3" column="1">
               <widget class="QLineEdit" name="keys"/>
              </item>
-             <item row="6" column="0">
+             <item row="7" column="0">
               <widget class="QLabel" name="label_6">
                <property name="text">
                 <string>Write Text:</string>
                </property>
               </widget>
              </item>
-             <item row="6" column="1">
+             <item row="7" column="1">
               <widget class="QPlainTextEdit" name="write"/>
              </item>
              <item row="4" column="0">
@@ -262,6 +275,27 @@
                </property>
               </widget>
              </item>
+             <item row="6" column="0">
+              <widget class="QLabel" name="label_9">
+               <property name="text">
+                <string>Information:</string>
+               </property>
+              </widget>
+             </item>
+             <item row="6" column="1">
+              <widget class="QComboBox" name="information">
+               <item>
+                <property name="text">
+                 <string>N/A</string>
+                </property>
+               </item>
+               <item>
+                <property name="text">
+                 <string>Current Time (H:M:S)</string>
+                </property>
+               </item>
+              </widget>
+             </item>
             </layout>
            </item>
           </layout>
@@ -279,7 +313,7 @@
      <x>0</x>
      <y>0</y>
      <width>844</width>
-     <height>30</height>
+     <height>22</height>
     </rect>
    </property>
    <widget class="QMenu" name="menuFile">

--- a/streamdeck_ui/ui_main.py
+++ b/streamdeck_ui/ui_main.py
@@ -10,6 +10,7 @@
 
 from PySide2 import QtCore, QtGui, QtWidgets
 
+
 class Ui_MainWindow(object):
     def setupUi(self, MainWindow):
         MainWindow.setObjectName("MainWindow")

--- a/streamdeck_ui/ui_main.py
+++ b/streamdeck_ui/ui_main.py
@@ -3,7 +3,7 @@
 # Form implementation generated from reading ui file 'streamdeck_ui/main.ui',
 # licensing of 'streamdeck_ui/main.ui' applies.
 #
-# Created: Fri Oct 30 20:27:39 2020
+# Created: Sat Oct 31 08:17:32 2020
 #      by: pyside2-uic  running on PySide2 5.13.2
 #
 # WARNING! All changes made in this file will be lost!
@@ -174,6 +174,8 @@ class Ui_MainWindow(object):
         self.information.setObjectName("information")
         self.information.addItem("")
         self.information.addItem("")
+        self.information.addItem("")
+        self.information.addItem("")
         self.formLayout.setWidget(6, QtWidgets.QFormLayout.FieldRole, self.information)
         self.verticalLayout_3.addLayout(self.formLayout)
         self.horizontalLayout.addWidget(self.groupBox)
@@ -227,6 +229,8 @@ class Ui_MainWindow(object):
         self.label_91.setText(QtWidgets.QApplication.translate("MainWindow", "Information:", None, -1))
         self.information.setItemText(0, QtWidgets.QApplication.translate("MainWindow", "N/A", None, -1))
         self.information.setItemText(1, QtWidgets.QApplication.translate("MainWindow", "Current Time (H:M:S)", None, -1))
+        self.information.setItemText(2, QtWidgets.QApplication.translate("MainWindow", "Current Time (H)", None, -1))
+        self.information.setItemText(3, QtWidgets.QApplication.translate("MainWindow", "Current Time (M)", None, -1))
         self.menuFile.setTitle(QtWidgets.QApplication.translate("MainWindow", "File", None, -1))
         self.actionImport.setText(QtWidgets.QApplication.translate("MainWindow", "Import", None, -1))
         self.actionExport.setText(QtWidgets.QApplication.translate("MainWindow", "Export", None, -1))

--- a/streamdeck_ui/ui_main.py
+++ b/streamdeck_ui/ui_main.py
@@ -3,13 +3,12 @@
 # Form implementation generated from reading ui file 'streamdeck_ui/main.ui',
 # licensing of 'streamdeck_ui/main.ui' applies.
 #
-# Created: Sun Oct  6 02:46:55 2019
-#      by: pyside2-uic  running on PySide2 5.13.1
+# Created: Fri Oct 30 20:27:39 2020
+#      by: pyside2-uic  running on PySide2 5.13.2
 #
 # WARNING! All changes made in this file will be lost!
 
 from PySide2 import QtCore, QtGui, QtWidgets
-
 
 class Ui_MainWindow(object):
     def setupUi(self, MainWindow):
@@ -27,24 +26,26 @@ class Ui_MainWindow(object):
         self.device_list.setMinimumSize(QtCore.QSize(400, 0))
         self.device_list.setObjectName("device_list")
         self.horizontalLayout_3.addWidget(self.device_list)
-        spacerItem = QtWidgets.QSpacerItem(
-            40, 20, QtWidgets.QSizePolicy.Expanding, QtWidgets.QSizePolicy.Minimum
-        )
+        spacerItem = QtWidgets.QSpacerItem(40, 20, QtWidgets.QSizePolicy.Expanding, QtWidgets.QSizePolicy.Minimum)
         self.horizontalLayout_3.addItem(spacerItem)
         self.label_4 = QtWidgets.QLabel(self.centralwidget)
-        sizePolicy = QtWidgets.QSizePolicy(
-            QtWidgets.QSizePolicy.Fixed, QtWidgets.QSizePolicy.Preferred
-        )
+        sizePolicy = QtWidgets.QSizePolicy(QtWidgets.QSizePolicy.Fixed, QtWidgets.QSizePolicy.Preferred)
         sizePolicy.setHorizontalStretch(0)
         sizePolicy.setVerticalStretch(0)
         sizePolicy.setHeightForWidth(self.label_4.sizePolicy().hasHeightForWidth())
         self.label_4.setSizePolicy(sizePolicy)
         self.label_4.setObjectName("label_4")
         self.horizontalLayout_3.addWidget(self.label_4)
+        self.label_9 = QtWidgets.QLabel(self.centralwidget)
+        sizePolicy = QtWidgets.QSizePolicy(QtWidgets.QSizePolicy.Fixed, QtWidgets.QSizePolicy.Preferred)
+        sizePolicy.setHorizontalStretch(0)
+        sizePolicy.setVerticalStretch(0)
+        sizePolicy.setHeightForWidth(self.label_9.sizePolicy().hasHeightForWidth())
+        self.label_9.setSizePolicy(sizePolicy)
+        self.label_9.setObjectName("label_9")
+        self.horizontalLayout_3.addWidget(self.label_9)
         self.brightness = QtWidgets.QSlider(self.centralwidget)
-        sizePolicy = QtWidgets.QSizePolicy(
-            QtWidgets.QSizePolicy.Minimum, QtWidgets.QSizePolicy.Fixed
-        )
+        sizePolicy = QtWidgets.QSizePolicy(QtWidgets.QSizePolicy.Minimum, QtWidgets.QSizePolicy.Fixed)
         sizePolicy.setHorizontalStretch(0)
         sizePolicy.setVerticalStretch(0)
         sizePolicy.setHeightForWidth(self.brightness.sizePolicy().hasHeightForWidth())
@@ -146,10 +147,10 @@ class Ui_MainWindow(object):
         self.formLayout.setWidget(3, QtWidgets.QFormLayout.FieldRole, self.keys)
         self.label_6 = QtWidgets.QLabel(self.groupBox)
         self.label_6.setObjectName("label_6")
-        self.formLayout.setWidget(6, QtWidgets.QFormLayout.LabelRole, self.label_6)
+        self.formLayout.setWidget(7, QtWidgets.QFormLayout.LabelRole, self.label_6)
         self.write = QtWidgets.QPlainTextEdit(self.groupBox)
         self.write.setObjectName("write")
-        self.formLayout.setWidget(6, QtWidgets.QFormLayout.FieldRole, self.write)
+        self.formLayout.setWidget(7, QtWidgets.QFormLayout.FieldRole, self.write)
         self.label_8 = QtWidgets.QLabel(self.groupBox)
         self.label_8.setObjectName("label_8")
         self.formLayout.setWidget(4, QtWidgets.QFormLayout.LabelRole, self.label_8)
@@ -166,13 +167,21 @@ class Ui_MainWindow(object):
         self.change_brightness.setMinimum(-99)
         self.change_brightness.setObjectName("change_brightness")
         self.formLayout.setWidget(5, QtWidgets.QFormLayout.FieldRole, self.change_brightness)
+        self.label_91 = QtWidgets.QLabel(self.groupBox)
+        self.label_91.setObjectName("label_91")
+        self.formLayout.setWidget(6, QtWidgets.QFormLayout.LabelRole, self.label_91)
+        self.information = QtWidgets.QComboBox(self.groupBox)
+        self.information.setObjectName("information")
+        self.information.addItem("")
+        self.information.addItem("")
+        self.formLayout.setWidget(6, QtWidgets.QFormLayout.FieldRole, self.information)
         self.verticalLayout_3.addLayout(self.formLayout)
         self.horizontalLayout.addWidget(self.groupBox)
         self.verticalLayout.addLayout(self.horizontalLayout)
         self.verticalLayout_2.addLayout(self.verticalLayout)
         MainWindow.setCentralWidget(self.centralwidget)
         self.menubar = QtWidgets.QMenuBar(MainWindow)
-        self.menubar.setGeometry(QtCore.QRect(0, 0, 844, 30))
+        self.menubar.setGeometry(QtCore.QRect(0, 0, 844, 22))
         self.menubar.setObjectName("menubar")
         self.menuFile = QtWidgets.QMenu(self.menubar)
         self.menuFile.setObjectName("menuFile")
@@ -193,75 +202,32 @@ class Ui_MainWindow(object):
         QtCore.QMetaObject.connectSlotsByName(MainWindow)
 
     def retranslateUi(self, MainWindow):
-        MainWindow.setWindowTitle(
-            QtWidgets.QApplication.translate("MainWindow", "MainWindow", None, -1)
-        )
-        self.label_4.setText(
-            QtWidgets.QApplication.translate("MainWindow", "Brightness:", None, -1)
-        )
-        self.pages.setTabText(
-            self.pages.indexOf(self.page_1),
-            QtWidgets.QApplication.translate("MainWindow", "Page 1", None, -1),
-        )
-        self.pages.setTabText(
-            self.pages.indexOf(self.page_2),
-            QtWidgets.QApplication.translate("MainWindow", "2", None, -1),
-        )
-        self.pages.setTabText(
-            self.pages.indexOf(self.page_3),
-            QtWidgets.QApplication.translate("MainWindow", "3", None, -1),
-        )
-        self.pages.setTabText(
-            self.pages.indexOf(self.page_4),
-            QtWidgets.QApplication.translate("MainWindow", "4", None, -1),
-        )
-        self.pages.setTabText(
-            self.pages.indexOf(self.page_5),
-            QtWidgets.QApplication.translate("MainWindow", "5", None, -1),
-        )
-        self.pages.setTabText(
-            self.pages.indexOf(self.page_6),
-            QtWidgets.QApplication.translate("MainWindow", "6", None, -1),
-        )
-        self.pages.setTabText(
-            self.pages.indexOf(self.page_7),
-            QtWidgets.QApplication.translate("MainWindow", "7", None, -1),
-        )
-        self.pages.setTabText(
-            self.pages.indexOf(self.page_8),
-            QtWidgets.QApplication.translate("MainWindow", "8", None, -1),
-        )
-        self.pages.setTabText(
-            self.pages.indexOf(self.page_9),
-            QtWidgets.QApplication.translate("MainWindow", "9", None, -1),
-        )
-        self.pages.setTabText(
-            self.pages.indexOf(self.tab_10),
-            QtWidgets.QApplication.translate("MainWindow", "10", None, -1),
-        )
-        self.groupBox.setTitle(
-            QtWidgets.QApplication.translate("MainWindow", "Configure Button", None, -1)
-        )
+        MainWindow.setWindowTitle(QtWidgets.QApplication.translate("MainWindow", "MainWindow", None, -1))
+        self.label_4.setText(QtWidgets.QApplication.translate("MainWindow", "Brightness:", None, -1))
+        self.label_9.setText(QtWidgets.QApplication.translate("MainWindow", "Information:", None, -1))
+        self.pages.setTabText(self.pages.indexOf(self.page_1), QtWidgets.QApplication.translate("MainWindow", "Page 1", None, -1))
+        self.pages.setTabText(self.pages.indexOf(self.page_2), QtWidgets.QApplication.translate("MainWindow", "2", None, -1))
+        self.pages.setTabText(self.pages.indexOf(self.page_3), QtWidgets.QApplication.translate("MainWindow", "3", None, -1))
+        self.pages.setTabText(self.pages.indexOf(self.page_4), QtWidgets.QApplication.translate("MainWindow", "4", None, -1))
+        self.pages.setTabText(self.pages.indexOf(self.page_5), QtWidgets.QApplication.translate("MainWindow", "5", None, -1))
+        self.pages.setTabText(self.pages.indexOf(self.page_6), QtWidgets.QApplication.translate("MainWindow", "6", None, -1))
+        self.pages.setTabText(self.pages.indexOf(self.page_7), QtWidgets.QApplication.translate("MainWindow", "7", None, -1))
+        self.pages.setTabText(self.pages.indexOf(self.page_8), QtWidgets.QApplication.translate("MainWindow", "8", None, -1))
+        self.pages.setTabText(self.pages.indexOf(self.page_9), QtWidgets.QApplication.translate("MainWindow", "9", None, -1))
+        self.pages.setTabText(self.pages.indexOf(self.tab_10), QtWidgets.QApplication.translate("MainWindow", "10", None, -1))
+        self.groupBox.setTitle(QtWidgets.QApplication.translate("MainWindow", "Configure Button", None, -1))
         self.label.setText(QtWidgets.QApplication.translate("MainWindow", "Image:", None, -1))
         self.imageButton.setText(QtWidgets.QApplication.translate("MainWindow", "Choose", None, -1))
         self.label_2.setText(QtWidgets.QApplication.translate("MainWindow", "Text:", None, -1))
         self.label_3.setText(QtWidgets.QApplication.translate("MainWindow", "Command:", None, -1))
-        self.label_5.setText(
-            QtWidgets.QApplication.translate("MainWindow", "Press Keys:", None, -1)
-        )
-        self.label_6.setText(
-            QtWidgets.QApplication.translate("MainWindow", "Write Text:", None, -1)
-        )
-        self.label_8.setText(
-            QtWidgets.QApplication.translate("MainWindow", "Switch Page:", None, -1)
-        )
-        self.label_7.setText(
-            QtWidgets.QApplication.translate("MainWindow", "Brightness +/-:", None, -1)
-        )
+        self.label_5.setText(QtWidgets.QApplication.translate("MainWindow", "Press Keys:", None, -1))
+        self.label_6.setText(QtWidgets.QApplication.translate("MainWindow", "Write Text:", None, -1))
+        self.label_8.setText(QtWidgets.QApplication.translate("MainWindow", "Switch Page:", None, -1))
+        self.label_7.setText(QtWidgets.QApplication.translate("MainWindow", "Brightness +/-:", None, -1))
+        self.label_91.setText(QtWidgets.QApplication.translate("MainWindow", "Information:", None, -1))
+        self.information.setItemText(0, QtWidgets.QApplication.translate("MainWindow", "N/A", None, -1))
+        self.information.setItemText(1, QtWidgets.QApplication.translate("MainWindow", "Current Time (H:M:S)", None, -1))
         self.menuFile.setTitle(QtWidgets.QApplication.translate("MainWindow", "File", None, -1))
-        self.actionImport.setText(
-            QtWidgets.QApplication.translate("MainWindow", "Import", None, -1)
-        )
-        self.actionExport.setText(
-            QtWidgets.QApplication.translate("MainWindow", "Export", None, -1)
-        )
+        self.actionImport.setText(QtWidgets.QApplication.translate("MainWindow", "Import", None, -1))
+        self.actionExport.setText(QtWidgets.QApplication.translate("MainWindow", "Export", None, -1))
+


### PR DESCRIPTION
I've added support for "live" information display. So far, the only built-in options are clock based (full time - H:M:S, just hour, and just minutes), but this can be easily expanded for all sorts of other feedback - CPU %, IP addresses, uptime, etc.

Here's what my Stream Deck XL looks like with an Hour and Minute key in the bottom-right:
![PXL_20201031_214345807](https://user-images.githubusercontent.com/4752520/97790674-e7a50100-1ba0-11eb-947a-ee265d7280e4.jpg)

I'm definitely open to suggestions on improving the UI for selecting the clock display (and how it overrides Text) - the best solution may be to have the clock options in a separate window/tab. Other options (including whether to display 12/24 hour, AM/PM,  format, etc.) could be added with additional screen space for the clock options.