### PR TITLE
Remove 'plugdev' group in fedora install

### DIFF
--- a/scripts/fedora_install.sh
+++ b/scripts/fedora_install.sh
@@ -2,13 +2,12 @@
 echo "Installing libraries"
 sudo dnf install python3-devel libusb-devel libusbx-devel libudev-devel systemd-devel
 echo "Adding udev rules and reloading"
-sudo usermod -a -G plugdev `whoami`
 
 sudo tee /etc/udev/rules.d/99-streamdeck.rules << EOF
-SUBSYSTEM=="usb", ATTRS{idVendor}=="0fd9", ATTRS{idProduct}=="0060", MODE:="666", GROUP="plugdev"
-SUBSYSTEM=="usb", ATTRS{idVendor}=="0fd9", ATTRS{idProduct}=="0063", MODE:="666", GROUP="plugdev"
-SUBSYSTEM=="usb", ATTRS{idVendor}=="0fd9", ATTRS{idProduct}=="006c", MODE:="666", GROUP="plugdev"
-SUBSYSTEM=="usb", ATTRS{idVendor}=="0fd9", ATTRS{idProduct}=="006d", MODE:="666", GROUP="plugdev"
+SUBSYSTEM=="usb", ATTRS{idVendor}=="0fd9", ATTRS{idProduct}=="0060", MODE:="0666"
+SUBSYSTEM=="usb", ATTRS{idVendor}=="0fd9", ATTRS{idProduct}=="0063", MODE:="0666"
+SUBSYSTEM=="usb", ATTRS{idVendor}=="0fd9", ATTRS{idProduct}=="006c", MODE:="0666"
+SUBSYSTEM=="usb", ATTRS{idVendor}=="0fd9", ATTRS{idProduct}=="006d", MODE:="0666"
 EOF
 
 sudo udevadm control --reload-rules


### PR DESCRIPTION
'plugdev' is an ubuntu-specific group and does
not exist on fedora. Thus, this patch removes the group and just
keeps the mode.