### PR TITLE
Add help flag and no-ui flag

### DIFF
--- a/streamdeck_ui/gui.py
+++ b/streamdeck_ui/gui.py
@@ -238,7 +238,7 @@ def queue_text_change(ui, text: str) -> None:
     text_timer.start(500)
 
 
-def start(_exit: bool = False) -> None:
+def start(_exit: bool = False, _show_ui: bool = True) -> None:
     app = QApplication(sys.argv)
 
     logo = QIcon(LOGO)
@@ -280,7 +280,10 @@ def start(_exit: bool = False) -> None:
 
     api.render()
     tray.show()
-    main_window.show()
+
+    if _show_ui:
+        main_window.show()
+
     if _exit:
         return
     else:
@@ -288,4 +291,12 @@ def start(_exit: bool = False) -> None:
 
 
 if __name__ == "__main__":
-    start()
+    if "-h" in sys.argv or "--help" in sys.argv:
+        print(f"Usage: {sys.argv[0]}")
+        print("Flags:")
+        print("\t-h/--help: Show this message")
+        print("\t-n/--no-ui: Run the program without showing a UI")
+    elif "-n" in sys.argv or "--no-ui" in sys.argv:
+        start(_show_ui = False)
+    else:
+        start()

--- a/streamdeck_ui/gui.py
+++ b/streamdeck_ui/gui.py
@@ -292,11 +292,11 @@ def start(_exit: bool = False, _show_ui: bool = True) -> None:
 
 if __name__ == "__main__":
     if "-h" in sys.argv or "--help" in sys.argv:
-        print(f"Usage: {sys.argv[0]}")
+        print(f"Usage: {os.path.basename(sys.argv[0])}")
         print("Flags:")
-        print("\t-h/--help: Show this message")
-        print("\t-n/--no-ui: Run the program without showing a UI")
+        print("  -h, --help:\tShow this message")
+        print("  -n, --no-ui:\tRun the program without showing a UI")
     elif "-n" in sys.argv or "--no-ui" in sys.argv:
-        start(_show_ui = False)
+        start(_show_ui=False)
     else:
         start()


### PR DESCRIPTION
Added a flag to run the program without a GUI (for if you just want to run it in the background, at system startup, for example). Also added a help flag (why not). I did this on my own machine and felt there was no reason not to submit a PR.

I was writing a script to lock my PC. Part of the script kills the streamdeck_ui process running in the background (so you cant use the stream deck while the PC's locked), and I wanted a way to start it back up again when I unlock without showing the UI. Hence I added this quick feature.

It worked fine in my quick manual tests, but let me know if it doesn't fit in with the rest of the codebase for some reason.