### PR TITLE
Do not rely on plugdev group and give access to user currently connected

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,22 +47,18 @@ If you're using GNOME shell, you might need to manually install an extension tha
 
 To use streamdeck_ui without root permissions, you have to give your user full access to the device.
 
-Add your user to the 'plugdev' group:
-```bash
-sudo usermod -a -G plugdev `whoami`
-```
 Add the udev rules using your text editor:
 ```bash
-sudoedit /etc/udev/rules.d/99-streamdeck.rules
+sudoedit /etc/udev/rules.d/70-streamdeck.rules
 # If that doesn't work, try:
-sudo nano /etc/udev/rules.d/99-streamdeck.rules
+sudo nano /etc/udev/rules.d/70-streamdeck.rules
 ```
 Paste the following lines:
 ```
-SUBSYSTEM=="usb", ATTRS{idVendor}=="0fd9", ATTRS{idProduct}=="0060", MODE:="660", GROUP="plugdev"
-SUBSYSTEM=="usb", ATTRS{idVendor}=="0fd9", ATTRS{idProduct}=="0063", MODE:="660", GROUP="plugdev"
-SUBSYSTEM=="usb", ATTRS{idVendor}=="0fd9", ATTRS{idProduct}=="006c", MODE:="660", GROUP="plugdev"
-SUBSYSTEM=="usb", ATTRS{idVendor}=="0fd9", ATTRS{idProduct}=="006d", MODE:="660", GROUP="plugdev"
+SUBSYSTEM=="usb", ATTRS{idVendor}=="0fd9", ATTRS{idProduct}=="0060", TAG+="uaccess"
+SUBSYSTEM=="usb", ATTRS{idVendor}=="0fd9", ATTRS{idProduct}=="0063", TAG+="uaccess"
+SUBSYSTEM=="usb", ATTRS{idVendor}=="0fd9", ATTRS{idProduct}=="006c", TAG+="uaccess"
+SUBSYSTEM=="usb", ATTRS{idVendor}=="0fd9", ATTRS{idProduct}=="006d", TAG+="uaccess"
 ```
 Reload the rules:
 ```

--- a/scripts/fedora_install.sh
+++ b/scripts/fedora_install.sh
@@ -1,16 +1,14 @@
 #!/bin/bash -xe
 echo "Installing libraries"
 sudo dnf install python3-devel libusb-devel libusbx-devel libudev-devel systemd-devel
+
 echo "Adding udev rules and reloading"
-sudo usermod -a -G plugdev `whoami`
-
-sudo tee /etc/udev/rules.d/99-streamdeck.rules << EOF
-SUBSYSTEM=="usb", ATTRS{idVendor}=="0fd9", ATTRS{idProduct}=="0060", MODE:="666", GROUP="plugdev"
-SUBSYSTEM=="usb", ATTRS{idVendor}=="0fd9", ATTRS{idProduct}=="0063", MODE:="666", GROUP="plugdev"
-SUBSYSTEM=="usb", ATTRS{idVendor}=="0fd9", ATTRS{idProduct}=="006c", MODE:="666", GROUP="plugdev"
-SUBSYSTEM=="usb", ATTRS{idVendor}=="0fd9", ATTRS{idProduct}=="006d", MODE:="666", GROUP="plugdev"
+sudo tee /etc/udev/rules.d/70-streamdeck.rules << EOF
+SUBSYSTEM=="usb", ATTRS{idVendor}=="0fd9", ATTRS{idProduct}=="0060", TAG+="uaccess"
+SUBSYSTEM=="usb", ATTRS{idVendor}=="0fd9", ATTRS{idProduct}=="0063", TAG+="uaccess"
+SUBSYSTEM=="usb", ATTRS{idVendor}=="0fd9", ATTRS{idProduct}=="006c", TAG+="uaccess"
+SUBSYSTEM=="usb", ATTRS{idVendor}=="0fd9", ATTRS{idProduct}=="006d", TAG+="uaccess"
 EOF
-
 sudo udevadm control --reload-rules
 
 echo "Unplug and replug in device for the new udev rules to take effect"

--- a/scripts/ubuntu_install.sh
+++ b/scripts/ubuntu_install.sh
@@ -1,16 +1,14 @@
 #!/bin/bash -xe
 echo "Installing libraries"
 sudo apt install qt5-default libhidapi-hidraw0 libudev-dev libusb-1.0-0-dev python3-pip
+
 echo "Adding udev rules and reloading"
-sudo usermod -a -G plugdev `whoami`
-
-sudo tee /etc/udev/rules.d/99-streamdeck.rules << EOF
-SUBSYSTEM=="usb", ATTRS{idVendor}=="0fd9", ATTRS{idProduct}=="0060", MODE:="666", GROUP="plugdev"
-SUBSYSTEM=="usb", ATTRS{idVendor}=="0fd9", ATTRS{idProduct}=="0063", MODE:="666", GROUP="plugdev"
-SUBSYSTEM=="usb", ATTRS{idVendor}=="0fd9", ATTRS{idProduct}=="006c", MODE:="666", GROUP="plugdev"
-SUBSYSTEM=="usb", ATTRS{idVendor}=="0fd9", ATTRS{idProduct}=="006d", MODE:="666", GROUP="plugdev"
+sudo tee /etc/udev/rules.d/70-streamdeck.rules << EOF
+SUBSYSTEM=="usb", ATTRS{idVendor}=="0fd9", ATTRS{idProduct}=="0060", TAG+="uaccess"
+SUBSYSTEM=="usb", ATTRS{idVendor}=="0fd9", ATTRS{idProduct}=="0063", TAG+="uaccess"
+SUBSYSTEM=="usb", ATTRS{idVendor}=="0fd9", ATTRS{idProduct}=="006c", TAG+="uaccess"
+SUBSYSTEM=="usb", ATTRS{idVendor}=="0fd9", ATTRS{idProduct}=="006d", TAG+="uaccess"
 EOF
-
 sudo udevadm control --reload-rules
 
 echo "Unplug and replug in device for the new udev rules to take effect"


### PR DESCRIPTION
With recent systems (less than 5 years old), users currently connected
in front of the screen automatically gets access to most "physical"
devices (webcam, joysticks) by using the "uaccess" mechanism.

No need to add the user to a plugdev group (which may not exist, as
noted in #76).