### PR TITLE
follow symlink when overwriting json config

### DIFF
--- a/streamdeck_ui/api.py
+++ b/streamdeck_ui/api.py
@@ -96,7 +96,7 @@ def export_config(output_file: str) -> None:
         print(f"The configuration file '{output_file}' was not updated. Error: {error}")
         raise
     else:
-        os.replace(output_file + ".tmp", output_file)
+        os.replace(output_file + ".tmp", os.path.realpath(output_file))
 
 
 def open_decks() -> Dict[str, Dict[str, Union[str, Tuple[int, int]]]]:


### PR DESCRIPTION
For users who'd like to backup/versioncontrol the json config in a separate dotfiles repo which uses symlinking. 

I noticed that my symlinked config attempt got replaced by a regular file every time I changed the configuration in the ui. This change makes sure symlinks are followed and kept intact when the config is exported.