### PR TITLE
Add slider to set the amount of dimming

### DIFF
--- a/streamdeck_ui/api.py
+++ b/streamdeck_ui/api.py
@@ -271,6 +271,18 @@ def get_brightness(deck_id: str) -> int:
     return state.get(deck_id, {}).get("brightness", 100)  # type: ignore
 
 
+def get_brightness_dimmed(deck_id: str) -> int:
+    """Gets the percentage value of the full brightness that is used when dimming the specified 
+    stream deck"""
+    return state.get(deck_id, {}).get("brightness_dimmed", 0)
+
+
+def set_brightness_dimmed(deck_id: str, brightness_dimmed: int) -> None:
+    """Sets the percentage value that will be used for dimming the full brightness"""
+    state.setdefault(deck_id, {})["brightness_dimmed"] = brightness_dimmed
+    _save_state()
+
+
 def change_brightness(deck_id: str, amount: int = 1) -> None:
     """Change the brightness of the deck by the specified amount"""
     set_brightness(deck_id, max(min(get_brightness(deck_id) + amount, 100), 0))

--- a/streamdeck_ui/gui.py
+++ b/streamdeck_ui/gui.py
@@ -59,12 +59,14 @@ dimmer_options = {
 class Dimmer:
     timeout = 0
     brightness = -1
+    brightness_dimmed = -1
     __stopped = False
     __dimmer_brightness = -1
     __timer = None
     __change_timer = None
 
-    def __init__(self, timeout: int, brightness: int, brightness_callback: Callable[[int], None]):
+    def __init__(self, timeout: int, brightness: int, brightness_dimmed: int,
+                 brightness_callback: Callable[[int], None]):
         """ Constructs a new Dimmer instance
 
         :param int timeout: The time in seconds before the dimmer starts.
@@ -74,6 +76,7 @@ class Dimmer:
          """
         self.timeout = timeout
         self.brightness = brightness
+        self.brightness_dimmed = brightness_dimmed
         self.brightness_callback = brightness_callback
 
     def stop(self) -> None:
@@ -133,7 +136,7 @@ class Dimmer:
 
     def change_brightness(self):
         """ Move the brightness level down by one and schedule another change_brightness event. """
-        if self.__dimmer_brightness:
+        if self.__dimmer_brightness and self.__dimmer_brightness >= self.brightness_dimmed:
             self.__dimmer_brightness = self.__dimmer_brightness - 1
             self.brightness_callback(self.__dimmer_brightness)
             self.__change_timer = QTimer()
@@ -396,6 +399,13 @@ def set_brightness(ui, value: int) -> None:
     dimmers[deck_id].reset()
 
 
+def set_brightness_dimmed(ui, value: int, full_brightness: int) -> None:
+    deck_id = _deck_id(ui)
+    api.set_brightness_dimmed(deck_id, value)
+    dimmers[deck_id].brightness_dimmed = int(full_brightness  * (value / 100))
+    dimmers[deck_id].reset()
+
+
 def button_clicked(ui, clicked_button, buttons) -> None:
     global selected_button
     selected_button = clicked_button
@@ -570,6 +580,9 @@ def show_settings(window) -> None:
     else:
         settings.ui.dim.setCurrentIndex(existing_index)
 
+    existing_brightness_dimmed = api.get_brightness_dimmed(deck_id)
+    settings.ui.brightness_dimmed.setValue(existing_brightness_dimmed)
+
     settings.ui.label_streamdeck.setText(deck_id)
     settings.ui.brightness.setValue(api.get_brightness(deck_id))
     settings.ui.brightness.valueChanged.connect(partial(change_brightness, deck_id))
@@ -579,6 +592,9 @@ def show_settings(window) -> None:
             dimmers[deck_id].timeout = settings.ui.dim.currentData()
             api.set_display_timeout(deck_id, settings.ui.dim.currentData())
         set_brightness(window.ui, settings.ui.brightness.value())
+        set_brightness_dimmed(
+            window.ui, settings.ui.brightness_dimmed.value(), settings.ui.brightness.value()
+        )
     else:
         # User cancelled, reset to original brightness
         change_brightness(deck_id, api.get_brightness(deck_id))
@@ -649,6 +665,7 @@ def start(_exit: bool = False) -> None:
         dimmers[deck_id] = Dimmer(
             api.get_display_timeout(deck_id),
             api.get_brightness(deck_id),
+            api.get_brightness_dimmed(deck_id),
             partial(change_brightness, deck_id),
         )
         dimmers[deck_id].reset()

--- a/streamdeck_ui/ui_settings.py
+++ b/streamdeck_ui/ui_settings.py
@@ -68,6 +68,17 @@ class Ui_SettingsDialog(object):
 
         self.formLayout.setWidget(2, QFormLayout.FieldRole, self.dim)
 
+        self.label_brightness_dimmed = QLabel(SettingsDialog)
+        self.label_brightness_dimmed.setObjectName(u"label_brightness_dimmed")
+
+        self.formLayout.setWidget(3, QFormLayout.LabelRole, self.label_brightness_dimmed)
+
+        self.brightness_dimmed = QSlider(SettingsDialog)
+        self.brightness_dimmed.setObjectName(u"brightness_dimmed")
+        self.brightness_dimmed.setOrientation(Qt.Horizontal)
+
+        self.formLayout.setWidget(3, QFormLayout.FieldRole, self.brightness_dimmed)
+
 
         self.verticalLayout_2.addLayout(self.formLayout)
 
@@ -96,6 +107,7 @@ class Ui_SettingsDialog(object):
         self.label_streamdeck.setText("")
         self.label_brightness.setText(QCoreApplication.translate("SettingsDialog", u"Brightness:", None))
         self.label_dim.setText(QCoreApplication.translate("SettingsDialog", u"Auto dim after:", None))
+        self.label_brightness_dimmed.setText(QCoreApplication.translate("SettingsDialog", u"Dim to %:", None))
         self.dim.setCurrentText("")
     # retranslateUi
 


### PR DESCRIPTION
Currently the dim setting will just turn off the streamdeck buttons entirely. This change introduces a Slider to the settings dialog to set the dimmed brightness to a percentage amount of the current full brightness. 

examples:
Brightness: 80
Dim to %: 50
Resulting Dimmed Brightness: 40


Brightness: 20
Dim to %: 75
Resulting Dimmed Brightness: 15