### PR TITLE
Note that logout/login is necessary for input.

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ Reload the rules:
 ``` console
 sudo udevadm control --reload-rules
 ```
-Make sure you unplug and replug your device before continuing.
+Make sure you unplug and replug your device before continuing.  For input to work, you'll need to log out and back in again so logind can assign you permission to read the Stream Deck's input device.
 Once complete, you should be able to install streamdeck_ui.
 Installing the application itself is done via pip:
 ``` console


### PR DESCRIPTION
With the uaccess tag in the udev rules, interaction is needed between systemd-logind, PAM and dbus to set the device permissions.  

This happens at login time, so at initial setup, a login/logout will be needed to get keypresses working.  Display works right away so it looks like steamdeck-ui is working fine but the buttons don't work.  Logging out and in fixes this.  

cf. https://unix.stackexchange.com/questions/467382/udev-uaccess-and-hid