### PR TITLE
Support for multiline text

### DIFF
--- a/docs/contributing/1.-contributing-guide.md
+++ b/docs/contributing/1.-contributing-guide.md
@@ -23,8 +23,9 @@ Once you have verified that you system matches the base requirements you can sta
 1. [Fork the project on GitHub](https://github.com/timothycrosley/streamdeck_ui/fork).
 2. Clone your fork to your local file system:
     `git clone https://github.com/$GITHUB_ACCOUNT/streamdeck_ui.git`
-3. `cd streamdeck_ui
+3. `cd streamdeck_ui`
 4. `poetry install`
+5. Test the app live with `poetry run streamdeck`.
 
 ## Making a contribution
 Congrats! You're now ready to make a contribution! Use the following as a guide to help you reach a successful pull-request:

--- a/docs/contributing/3.-code-of-conduct.md
+++ b/docs/contributing/3.-code-of-conduct.md
@@ -81,7 +81,7 @@ members of the project's leadership.
 
 ## Attribution
 
-This Code of Conduct is adapted from the [Contributor Covenant][https://www.contributor-covenant.org], version 1.4,
+This Code of Conduct is adapted from the [Contributor Covenant](https://www.contributor-covenant.org), version 1.4,
 available at https://www.contributor-covenant.org/version/1/4/code-of-conduct.html
 
 For answers to common questions about this code of conduct, see

--- a/streamdeck_ui/gui.py
+++ b/streamdeck_ui/gui.py
@@ -400,7 +400,7 @@ def redraw_buttons(ui) -> None:
     current_tab = ui.pages.currentWidget()
     buttons = current_tab.findChildren(QtWidgets.QToolButton)
     for button in buttons:
-        button.setText(api.get_button_text(deck_id, _page(ui), button.index))
+        button.setText(api.get_button_text(deck_id, _page(ui), button.index, True))
         button.setIcon(QIcon(api.get_button_icon(deck_id, _page(ui), button.index)))
 
 


### PR DESCRIPTION
In this PR, I've introduced support for multiline text using `\n`. The idea comes from Bitfocus Companion.  
It will be stored as a literal `\n` (`\\n`), so that in UI in the input field, it is obvious, instead of appearing as whitespace.

Also, tweaked a bit the vertical centering of text when no icon is set, previously it was a bit offset by a couple of pixels more, now it just does the correct math instead.

A note, on why I'm passing the whole button state to `transform_button_text` instead of the text right away: The idea is that, at some point, I would like to also implement some dynamic stuff that would use that state as a context.

*This is my first time writing actual code on Python, so I am looking forward to your comments/suggestions.*