### PR TITLE
add run when locked option to buttons

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -320,6 +320,14 @@ doc = ["sphinx", "sphinx-rtd-theme"]
 test = ["pytest", "pytest-cov", "pytest-flake8", "pytest-isort", "coverage"]
 
 [[package]]
+name = "dbus-python"
+version = "1.2.18"
+description = "Python bindings for libdbus"
+category = "main"
+optional = false
+python-versions = "*"
+
+[[package]]
 name = "debugpy"
 version = "1.6.0"
 description = "An implementation of the Debug Adapter Protocol for Python"
@@ -1890,7 +1898,7 @@ testing = ["pytest (>=6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytest-
 [metadata]
 lock-version = "1.1"
 python-versions = ">=3.8,<3.11"
-content-hash = "1a0bf29986cbf4d0c101dda4c6119149ecdfa22a4983a40171d5f648830414e2"
+content-hash = "d07e93af8953f7e1b62ceb7a0ae31c7db9a8d4078e41a20aa35d4bdc86d1ca28"
 
 [metadata.files]
 appdirs = [
@@ -2097,6 +2105,9 @@ cruft = [
 cssselect2 = [
     {file = "cssselect2-0.6.0-py3-none-any.whl", hash = "sha256:3a83b2a68370c69c9cd3fcb88bbfaebe9d22edeef2c22d1ff3e1ed9c7fa45ed8"},
     {file = "cssselect2-0.6.0.tar.gz", hash = "sha256:5b5d6dea81a5eb0c9ca39f116c8578dd413778060c94c1f51196371618909325"},
+]
+dbus-python = [
+    {file = "dbus-python-1.2.18.tar.gz", hash = "sha256:92bdd1e68b45596c833307a5ff4b217ee6929a1502f5341bae28fd120acf7260"},
 ]
 debugpy = [
     {file = "debugpy-1.6.0-cp310-cp310-macosx_10_15_x86_64.whl", hash = "sha256:eb1946efac0c0c3d411cea0b5ac772fbde744109fd9520fb0c5a51979faf05ad"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,7 @@ pyside2 = "^5.15"
 CairoSVG = "^2.5.2"
 filetype = "^1.0.10"
 python-xlib = "^0.31"
+dbus-python = "^1.2.18"
 
 [tool.poetry.dev-dependencies]
 vulture = "^1.0"

--- a/streamdeck_ui/api.py
+++ b/streamdeck_ui/api.py
@@ -363,6 +363,16 @@ class StreamDeckServer:
         """Returns the brightness change set for a particular button"""
         return self._button_state(deck_id, page, button).get("brightness_change", 0)
 
+    def set_button_run_when_locked(self, deck_id: str, page: int, button: int, value: bool) -> None:
+        """Sets whether the button should run when the system is locked"""
+        if self.get_button_run_when_locked(deck_id, page, button) != value:
+            self._button_state(deck_id, page, button)["run_when_locked"] = value
+            self._save_state()
+
+    def get_button_run_when_locked(self, deck_id: str, page: int, button: int) -> bool:
+        """Returns whether the button should run when the system is locked"""
+        return self._button_state(deck_id, page, button).get("run_when_locked", False)
+
     def set_button_command(self, deck_id: str, page: int, button: int, command: str) -> None:
         """Sets the command associated with the button"""
         if self.get_button_command(deck_id, page, button) != command:

--- a/streamdeck_ui/main.ui
+++ b/streamdeck_ui/main.ui
@@ -428,13 +428,24 @@
               </widget>
              </item>
              <item row="6" column="0">
+              <widget class="QLabel" name="label_run_when_locked">
+               <property name="text">
+                <string>Run when locked:</string>
+               </property>
+              </widget>
+             </item>
+             <item row="6" column="1">
+              <widget class="QCheckBox" name="run_when_locked">
+              </widget>
+             </item>
+             <item row="7" column="0">
               <widget class="QLabel" name="label_6">
                <property name="text">
                 <string>Write Text:</string>
                </property>
               </widget>
              </item>
-             <item row="6" column="1">
+             <item row="7" column="1">
               <widget class="QPlainTextEdit" name="write"/>
              </item>
              <item row="1" column="1">

--- a/streamdeck_ui/system_api.py
+++ b/streamdeck_ui/system_api.py
@@ -1,0 +1,16 @@
+import dbus
+
+
+class SystemApi:
+
+    def __init__(self):
+        self.bus = dbus.SystemBus()
+
+    def get_is_system_locked(self) -> bool:
+        login1 = self.bus.get_object('org.freedesktop.login1',
+                                 '/org/freedesktop/login1/session/auto')
+        properties_interface = dbus.Interface(login1, 'org.freedesktop.DBus.Properties')
+        session_properties = properties_interface.GetAll('org.freedesktop.login1.Session')
+        system_is_locked = session_properties.get('LockedHint')
+
+        return bool(system_is_locked)

--- a/streamdeck_ui/ui_main.py
+++ b/streamdeck_ui/ui_main.py
@@ -259,15 +259,25 @@ class Ui_MainWindow(object):
 
         self.formLayout.setWidget(5, QFormLayout.FieldRole, self.change_brightness)
 
+        self.label_run_when_locked = QLabel(self.groupBox)
+        self.label_run_when_locked.setObjectName(u"label_run_when_locked")
+
+        self.formLayout.setWidget(6, QFormLayout.LabelRole, self.label_run_when_locked)
+
+        self.run_when_locked = QCheckBox(self.groupBox)
+        self.run_when_locked.setObjectName(u"run_when_locked")
+
+        self.formLayout.setWidget(6, QFormLayout.FieldRole, self.run_when_locked)
+
         self.label_6 = QLabel(self.groupBox)
         self.label_6.setObjectName(u"label_6")
 
-        self.formLayout.setWidget(6, QFormLayout.LabelRole, self.label_6)
+        self.formLayout.setWidget(7, QFormLayout.LabelRole, self.label_6)
 
         self.write = QPlainTextEdit(self.groupBox)
         self.write.setObjectName(u"write")
 
-        self.formLayout.setWidget(6, QFormLayout.FieldRole, self.write)
+        self.formLayout.setWidget(7, QFormLayout.FieldRole, self.write)
 
         self.horizontalLayout_3 = QHBoxLayout()
         self.horizontalLayout_3.setObjectName(u"horizontalLayout_3")
@@ -323,7 +333,8 @@ class Ui_MainWindow(object):
         QWidget.setTabOrder(self.command, self.keys)
         QWidget.setTabOrder(self.keys, self.switch_page)
         QWidget.setTabOrder(self.switch_page, self.change_brightness)
-        QWidget.setTabOrder(self.change_brightness, self.write)
+        QWidget.setTabOrder(self.change_brightness, self.run_when_locked)
+        QWidget.setTabOrder(self.run_when_locked, self.write)
 
         self.menubar.addAction(self.menuFile.menuAction())
         self.menubar.addAction(self.menuHelp.menuAction())
@@ -377,6 +388,7 @@ class Ui_MainWindow(object):
 
         self.label_8.setText(QCoreApplication.translate("MainWindow", u"Switch Page:", None))
         self.label_7.setText(QCoreApplication.translate("MainWindow", u"Brightness +/-:", None))
+        self.label_run_when_locked.setText(QCoreApplication.translate("MainWindow", u"Run When Locked:", None))
         self.label_6.setText(QCoreApplication.translate("MainWindow", u"Write Text:", None))
 #if QT_CONFIG(tooltip)
         self.textButton.setToolTip(QCoreApplication.translate("MainWindow", u"Text vertical alignment", None))


### PR DESCRIPTION
Initial POC for blocking buttons from running when the system is locked. Uses dbus-python.

* [x] Add lock check when button is pressed
* [x] block button press unless button is enabled when system is locked
* [x] add check box to UI to configure buttons that should be allowed to run when locked
* [ ] connect to lock/unlock signals and update text/button on the stream deck for buttons that cannot run when the system is locked

issue #46 