### PR TITLE
fix: works fine on python 3.11

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ license = "MIT"
 readme = "README.md"
 
 [tool.poetry.dependencies]
-python = ">=3.8,<3.11"
+python = ">=3.8,<3.12"
 streamdeck = "^0.9.2"
 pillow = "^9.2.0"
 pynput = "^1.7"


### PR DESCRIPTION
Void updated to Python 3.11. I shimmed this version requirement and the package installs and runs.