### PR TITLE
✅ Add a manual for openSUSE based distro's & solved the udev rule's bug!

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,12 @@ Fedora:
 ``` console
 sudo dnf install python3-pip python3-devel hidapi
 ```
+
+openSUSE Leap & Tumbleweed:
+``` console
+sudo zypper install python3-pip libhidapi-libusb0 libxcb-xinerama0 python-devel python3-devel python310 python310-devel gcc gcc-c++ kernel-devel
+```
+
 If you're using GNOME shell, you might need to manually install an extension that adds [KStatusNotifierItem/AppIndicator Support](https://extensions.gnome.org/extension/615/appindicator-support/) to make the tray icon show up.
 
 To use streamdeck_ui without root permissions, you have to give your user full access to the device.

--- a/README.md
+++ b/README.md
@@ -58,22 +58,34 @@ If you're using GNOME shell, you might need to manually install an extension tha
 
 To use streamdeck_ui without root permissions, you have to give your user full access to the device.
 
-Add the udev rules using the nano text editor:
+List USB Devices Details using lsusb Command
+``` console
+lsusb
+```
+Then search for your Elgato Stream Deck like this one:
+![lsusb-elgato_stream_deck](https://user-images.githubusercontent.com/79079633/205458785-6e1c092c-cd12-48fb-8637-0e3dfe0f6f87.jpg)
+
+Now we have all the information to add a specific udev rule using for example the nano text editor:
 ``` console
 sudo nano /etc/udev/rules.d/70-streamdeck.rules
 ```
 Paste the following line and write the file:
 ``` console 
-SUBSYSTEM=="usb", ATTRS{idVendor}=="0fd9", TAG+="uaccess"
+SUBSYSTEM=="usb", ATTRS{idVendor}=="0fd9", ATTRS{idProduct}=="0080", TAG+="uaccess"
 ```
 Make the new rule take effect:
 ``` console
 sudo udevadm trigger
 ```
+or
+
+``` console
+sudo udevadm control --reload-rules
+```
 
 Installing the application itself is done via pip:
 ``` console
-pip3 install streamdeck-ui --user
+pip3 install wheel pillow streamdeck-ui --user
 ```
 Make sure to include `$HOME/.local/bin` to your PATH.  
 If you haven't already, add

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ sudo dnf install python3-pip python3-devel hidapi
 
 openSUSE Leap & Tumbleweed:
 ``` console
-sudo zypper install python3-pip libhidapi-libusb0 libxcb-xinerama0 python-devel python3-devel python310 python310-devel gcc gcc-c++ kernel-devel
+sudo zypper install python3-pip libhidapi-libusb0 libxcb-xinerama0 python310 python310-devel kernel-devel
 ```
 
 If you're using GNOME shell, you might need to manually install an extension that adds [KStatusNotifierItem/AppIndicator Support](https://extensions.gnome.org/extension/615/appindicator-support/) to make the tray icon show up.
@@ -85,7 +85,7 @@ sudo udevadm control --reload-rules
 
 Installing the application itself is done via pip:
 ``` console
-pip3 install wheel pillow streamdeck-ui --user
+pip3 install streamdeck-ui --user
 ```
 Make sure to include `$HOME/.local/bin` to your PATH.  
 If you haven't already, add


### PR DESCRIPTION
With this guide it is now also possible to use the various Elgato stream decks on openSUSE Leap & Tumbleweed. - Created by @cryinkfly