### PR TITLE
Update python-xlib 0.31 -> 0.33

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -1520,7 +1520,7 @@ unidecode = ["Unidecode (>=1.1.1)"]
 
 [[package]]
 name = "python-xlib"
-version = "0.31"
+version = "0.33"
 description = "Python X Library"
 category = "main"
 optional = false
@@ -2824,8 +2824,8 @@ python-slugify = [
     {file = "python_slugify-6.1.2-py2.py3-none-any.whl", hash = "sha256:7b2c274c308b62f4269a9ba701aa69a797e9bca41aeee5b3a9e79e36b6656927"},
 ]
 python-xlib = [
-    {file = "python-xlib-0.31.tar.gz", hash = "sha256:74d83a081f532bc07f6d7afcd6416ec38403d68f68b9b9dc9e1f28fbf2d799e9"},
-    {file = "python_xlib-0.31-py2.py3-none-any.whl", hash = "sha256:1ec6ce0de73d9e6592ead666779a5732b384e5b8fb1f1886bd0a81cafa477759"},
+    {file = "python-xlib-0.33.tar.gz", hash = "sha256:55af7906a2c75ce6cb280a584776080602444f75815a7aff4d287bb2d7018b32"},
+    {file = "python_xlib-0.33-py2.py3-none-any.whl", hash = "sha256:c3534038d42e0df2f1392a1b30a15a4ff5fdc2b86cfa94f072bf11b10a164398"},
 ]
 pywin32 = [
     {file = "pywin32-303-cp310-cp310-win32.whl", hash = "sha256:6fed4af057039f309263fd3285d7b8042d41507343cd5fa781d98fcc5b90e8bb"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ pynput = "^1.7"
 pyside2 = "^5.15"
 CairoSVG = "^2.5.2"
 filetype = "^1.0.10"
-python-xlib = "^0.31"
+python-xlib = "^0.33"
 
 [tool.poetry.dev-dependencies]
 vulture = "^1.0"


### PR DESCRIPTION
Update `python-xlib` to include various bug fixes.

Release notes:

- [0.32](https://github.com/python-xlib/python-xlib/releases/tag/0.32)
- [0.33](https://github.com/python-xlib/python-xlib/releases/tag/0.33)

Tested on NixOS 22.11.