### PR TITLE
Operating StreamDeck from a terminal

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,6 +40,7 @@ types-pkg-resources = "^0.1.3"
 
 [tool.poetry.scripts]
 streamdeck = "streamdeck_ui.gui:start"
+streamdeckc = "streamdeck_ui.cli.server:execute"
 [build-system]
 requires = ["poetry-core"]
 build-backend = "poetry.core.masonry.api"

--- a/streamdeck_ui/cli/commands.py
+++ b/streamdeck_ui/cli/commands.py
@@ -135,18 +135,18 @@ def create_command(cfg: dict) -> Command | None:
         return SetPageCommand(cfg)
     elif cfg["command"] == "set_brightness":
         return SetBrightnessCommand(cfg)
-    elif cfg["command"] == "set_button_text":
+    elif cfg["command"] == "set_text":
         return SetButtonTextCommand(cfg)
     elif cfg["command"] == "set_alignment":
         return SetButtonTextAlignmentCommand(cfg)
-    elif cfg["command"] == "set_button_write":
+    elif cfg["command"] == "set_write":
         return SetButtonWriteCommand(cfg)
-    elif cfg["command"] == "set_button_cmd":
+    elif cfg["command"] == "set_cmd":
         return SetButtonCmdCommand(cfg)
-    elif cfg["command"] == "set_button_keys":
+    elif cfg["command"] == "set_keys":
         return SetButtonKeysCommand(cfg)
-    elif cfg["command"] == "set_button_icon":
+    elif cfg["command"] == "set_icon":
         return SetButtonIconCommand(cfg)
-    elif cfg["command"] == "clear_button_icon":
+    elif cfg["command"] == "clear_icon":
         return ClearButtonIconCommand(cfg)
     return None

--- a/streamdeck_ui/cli/commands.py
+++ b/streamdeck_ui/cli/commands.py
@@ -2,9 +2,11 @@ import typing as tp
 
 from streamdeck_ui.api import StreamDeckServer
 
+
 class Command(tp.Protocol):
     def execute(self, api: StreamDeckServer, ui: tp.Any) -> None:
         ...
+
 
 class SetPageCommand:
     def __init__(self, cfg):
@@ -18,6 +20,7 @@ class SetPageCommand:
         api.set_page(deck_id, self.page_index)
         ui.pages.setCurrentIndex(self.page_index)
 
+
 class SetBrightnessCommand:
     def __init__(self, cfg):
         self.deck_index = cfg["deck"]
@@ -26,6 +29,7 @@ class SetBrightnessCommand:
     def execute(self, api: StreamDeckServer, ui):
         deck_id = ui.device_list.itemData(ui.device_list.currentIndex()) if self.deck_index is None else self.deck_index
         api.set_brightness(deck_id, self.brightness)
+
 
 class SetButtonTextCommand:
     def __init__(self, cfg):
@@ -40,6 +44,7 @@ class SetButtonTextCommand:
             self.page_index = api.get_page(deck_id)
         api.set_button_text(deck_id, self.page_index, self.button_index, self.button_text)
 
+
 class SetButtonTextAlignmentCommand:
     def __init__(self, cfg):
         self.deck_index = cfg["deck"]
@@ -53,6 +58,7 @@ class SetButtonTextAlignmentCommand:
             self.page_index = api.get_page(deck_id)
         api.set_text_vertical_align(deck_id, self.page_index, self.button_index, self.button_text_alignment)
 
+
 class SetButtonWriteCommand:
     def __init__(self, cfg):
         self.deck_index = cfg["deck"]
@@ -65,6 +71,7 @@ class SetButtonWriteCommand:
         if self.page_index is None:
             self.page_index = api.get_page(deck_id)
         api.set_button_write(deck_id, self.page_index, self.button_index, self.button_write)
+
 
 class SetButtonCmdCommand:
     def __init__(self, cfg):
@@ -80,6 +87,7 @@ class SetButtonCmdCommand:
             self.page_index = api.get_page(deck_id)
         api.set_button_command(deck_id, self.page_index, self.button_index, self.button_cmd)
 
+
 class SetButtonKeysCommand:
     def __init__(self, cfg):
         self.deck_index = cfg["deck"]
@@ -94,6 +102,7 @@ class SetButtonKeysCommand:
             self.page_index = api.get_page(deck_id)
         api.set_button_keys(deck_id, self.page_index, self.button_index, self.button_keys)
 
+
 class SetButtonIconCommand:
     def __init__(self, cfg):
         self.deck_index = cfg["deck"]
@@ -107,6 +116,7 @@ class SetButtonIconCommand:
             self.page_index = api.get_page(deck_id)
         api.set_button_icon(deck_id, self.page_index, self.button_index, self.icon_path)
 
+
 class ClearButtonIconCommand:
     def __init__(self, cfg):
         self.deck_index = cfg["deck"]
@@ -117,17 +127,26 @@ class ClearButtonIconCommand:
         deck_id = ui.device_list.itemData(ui.device_list.currentIndex()) if self.deck_index is None else self.deck_index
         if self.page_index is None:
             self.page_index = api.get_page(deck_id)
-        api.set_button_icon(deck_id, self.page_index, self.button_index, None)
+        api.set_button_icon(deck_id, self.page_index, self.button_index, "")
 
-def create_command(cfg: dict) -> Command:
-    match cfg["command"]:
-        case "set_page": return SetPageCommand(cfg)
-        case "set_brightness": return SetBrightnessCommand(cfg)
-        case "set_button_text": return SetButtonTextCommand(cfg)
-        case "set_alignment": return SetButtonTextAlignmentCommand(cfg)
-        case "set_button_write": return SetButtonWriteCommand(cfg)
-        case "set_button_cmd": return SetButtonCmdCommand(cfg)
-        case "set_button_keys": return SetButtonKeysCommand(cfg)
-        case "set_button_icon": return SetButtonIconCommand(cfg)
-        case "clear_button_icon": return ClearButtonIconCommand(cfg)
+
+def create_command(cfg: dict) -> Command | None:
+    if cfg["command"] == "set_page":
+        return SetPageCommand(cfg)
+    elif cfg["command"] == "set_brightness":
+        return SetBrightnessCommand(cfg)
+    elif cfg["command"] == "set_button_text":
+        return SetButtonTextCommand(cfg)
+    elif cfg["command"] == "set_alignment":
+        return SetButtonTextAlignmentCommand(cfg)
+    elif cfg["command"] == "set_button_write":
+        return SetButtonWriteCommand(cfg)
+    elif cfg["command"] == "set_button_cmd":
+        return SetButtonCmdCommand(cfg)
+    elif cfg["command"] == "set_button_keys":
+        return SetButtonKeysCommand(cfg)
+    elif cfg["command"] == "set_button_icon":
+        return SetButtonIconCommand(cfg)
+    elif cfg["command"] == "clear_button_icon":
+        return ClearButtonIconCommand(cfg)
     return None

--- a/streamdeck_ui/cli/commands.py
+++ b/streamdeck_ui/cli/commands.py
@@ -1,0 +1,24 @@
+import typing as tp
+
+from streamdeck_ui.api import StreamDeckServer
+
+class Command(tp.Protocol):
+    def execute(self, api: StreamDeckServer, ui: tp.Any) -> None:
+        ...
+
+class PageChangeCommand:
+    def __init__(self, cfg):
+        self.page_index = cfg["page"]
+
+    def execute(self, api: StreamDeckServer, ui):
+        deck_id = ui.device_list.itemData(ui.device_list.currentIndex())
+        if api.get_page(deck_id) == self.page_index:
+            return
+        api.set_page(deck_id, self.page_index)
+        ui.pages.setCurrentIndex(self.page_index)
+
+
+def create_command(cfg: dict) -> Command:
+    if(cfg["command"] == "page_change"):
+        return PageChangeCommand(cfg)
+    return None

--- a/streamdeck_ui/cli/server.py
+++ b/streamdeck_ui/cli/server.py
@@ -4,6 +4,7 @@ import json
 import socket
 from threading import Event, Thread
 
+from streamdeck_ui.cli.commands import create_command
 from streamdeck_ui.api import StreamDeckServer
 
 def read_json(sock: socket.socket) -> dict:
@@ -25,6 +26,9 @@ class CLIStreamDeckServer:
     def __init__(self, api: StreamDeckServer, ui):
         self.quit = Event()
         self.cli_thread = None
+        
+        self.api = api
+        self.ui = ui
 
         self.sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
 
@@ -54,7 +58,9 @@ class CLIStreamDeckServer:
         while not self.quit.is_set():
             try:
                 conn, _ = self.sock.accept()
-                data = read_json(conn)
+                cfg = read_json(conn)
+                cmd = create_command(cfg)
+                cmd.execute(self.api, self.ui)
                 conn.close()
             except:
                 pass

--- a/streamdeck_ui/cli/server.py
+++ b/streamdeck_ui/cli/server.py
@@ -45,9 +45,13 @@ class CLIStreamDeckServer:
             pass
 
     def _run(self):
+        self.sock.listen(1)
+        self.sock.settimeout(CLIStreamDeckServer.SOCKET_CONNECTION_TIMEOUT_SECOND)
+
         while not self.quit.is_set():
             try:
-                # handle cli request
-                pass
+                conn, _ = self.sock.accept()
+                data = read_json(conn)
+                conn.close()
             except:
                 pass

--- a/streamdeck_ui/cli/server.py
+++ b/streamdeck_ui/cli/server.py
@@ -4,6 +4,8 @@ import json
 import socket
 from threading import Event, Thread
 
+from streamdeck_ui.api import StreamDeckServer
+
 def read_json(sock: socket.socket) -> dict:
     header = sock.recv(4)
     num_bytes = int.from_bytes(header, "little")
@@ -20,7 +22,7 @@ def write_json(sock: socket.socket, data: dict) -> None:
 class CLIStreamDeckServer:
     SOCKET_CONNECTION_TIMEOUT_SECOND = 0.5
 
-    def __init__(self):
+    def __init__(self, api: StreamDeckServer, ui):
         self.quit = Event()
         self.cli_thread = None
 
@@ -45,6 +47,7 @@ class CLIStreamDeckServer:
             pass
 
     def _run(self):
+        self.sock.bind("/tmp/streamdeck.sock")
         self.sock.listen(1)
         self.sock.settimeout(CLIStreamDeckServer.SOCKET_CONNECTION_TIMEOUT_SECOND)
 
@@ -55,3 +58,7 @@ class CLIStreamDeckServer:
                 conn.close()
             except:
                 pass
+        try:
+            os.remove("/tmp/streamdeck.sock")
+        except OSError:
+            pass

--- a/streamdeck_ui/cli/server.py
+++ b/streamdeck_ui/cli/server.py
@@ -1,7 +1,21 @@
 import os
 import sys
+import json
 import socket
 from threading import Event, Thread
+
+def read_json(sock: socket.socket):
+    header = sock.recv(4)
+    num_bytes = int.from_bytes(header, "little")
+
+    return json.loads(sock.recv(num_bytes))
+
+def write_json(sock: socket.socket, data: dict):
+    binary_data = json.dumps(data).encode("utf-8")
+    num_bytes = len(binary_data)
+
+    sock.send(num_bytes.to_bytes(4, "little"))
+    sock.send(binary_data)
 
 class CLIStreamDeckServer:
     SOCKET_CONNECTION_TIMEOUT_SECOND = 0.5

--- a/streamdeck_ui/cli/server.py
+++ b/streamdeck_ui/cli/server.py
@@ -1,0 +1,39 @@
+import os
+import sys
+import socket
+from threading import Event, Thread
+
+class CLIStreamDeckServer:
+    SOCKET_CONNECTION_TIMEOUT_SECOND = 0.5
+
+    def __init__(self):
+        self.quit = Event()
+        self.cli_thread = None
+
+        self.sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+
+    def start(self):
+        if not self.quit.is_set:
+            return
+        
+        self.cli_thread = Thread(target=self._run)
+        self.quit.clear()
+        self.cli_thread.start()
+
+    def stop(self):
+        if(self.quit.is_set()):
+            return
+
+        self.quit.set()
+        try:
+            self.cli_thread.join()
+        except RuntimeError:
+            pass
+
+    def _run(self):
+        while not self.quit.is_set():
+            try:
+                # handle cli request
+                pass
+            except:
+                pass

--- a/streamdeck_ui/cli/server.py
+++ b/streamdeck_ui/cli/server.py
@@ -51,7 +51,11 @@ class CLIStreamDeckServer:
             pass
 
     def _run(self):
-        self.sock.bind("/tmp/streamdeck.sock")
+        try: # If streamdeck.sock already exists, destroy it and bind a new one.
+            os.remove("/tmp/streamdeck_ui.sock")
+        except OSError:
+            pass
+        self.sock.bind("/tmp/streamdeck_ui.sock")
         self.sock.listen(1)
         self.sock.settimeout(CLIStreamDeckServer.SOCKET_CONNECTION_TIMEOUT_SECOND)
 
@@ -65,6 +69,6 @@ class CLIStreamDeckServer:
             except:
                 pass
         try:
-            os.remove("/tmp/streamdeck.sock")
+            os.remove("/tmp/streamdeck_ui.sock")
         except OSError:
             pass

--- a/streamdeck_ui/cli/server.py
+++ b/streamdeck_ui/cli/server.py
@@ -4,13 +4,13 @@ import json
 import socket
 from threading import Event, Thread
 
-def read_json(sock: socket.socket):
+def read_json(sock: socket.socket) -> dict:
     header = sock.recv(4)
     num_bytes = int.from_bytes(header, "little")
 
     return json.loads(sock.recv(num_bytes))
 
-def write_json(sock: socket.socket, data: dict):
+def write_json(sock: socket.socket, data: dict) -> None:
     binary_data = json.dumps(data).encode("utf-8")
     num_bytes = len(binary_data)
 

--- a/streamdeck_ui/cli/server.py
+++ b/streamdeck_ui/cli/server.py
@@ -120,78 +120,70 @@ def execute():
     data = None
 
     if options.action is not None:
-        match options.action.lower():
-            case "set_page":
-                if options.page_index is None:
-                    print("error: --page not set...")
-                    return
-                data = {"command": "set_page", "deck": options.deck_index, "page": options.page_index}
-
-            case "set_brightness":
-                if options.brightness is None:
-                    print("error: --brightness not set...")
-                    return
-                data = {"command": "set_brightness", "deck": options.deck_index, "value": options.brightness}
-
-            case "set_text":
-                if options.button_text is None:
-                    print("error: --text not set...")
-                    return
-                if options.button_index is None:
-                    print("error: --button not set...")
-                    return
-                data = {"command": "set_button_text", "deck": options.deck_index, "page": options.page_index, "button": options.button_index, "text": options.button_text}
-
-            case "set_write":
-                if options.button_write is None:
-                    print("error: --write not set...")
-                    return
-                if options.button_index is None:
-                    print("error: --button not set...")
-                    return
-                data = {"command": "set_button_write", "deck": options.deck_index, "page": options.page_index, "button": options.button_index, "write": options.button_write}
-
-            case "set_alignment":
-                if options.button_text_alignment is None:
-                    print("error: --alignment not set...")
-                    return
-                if options.button_index is None:
-                    print("error: --button not set...")
-                    return
-                data = {"command": "set_alignment", "deck": options.deck_index, "page": options.page_index, "button": options.button_index, "alignment": options.button_text_alignment}
-
-            case "set_cmd":
-                if options.button_cmd is None:
-                    print("error: --command not set...")
-                    return
-                if options.button_index is None:
-                    print("error: --button not set...")
-                    return
-                data = {"command": "set_button_cmd", "deck": options.deck_index, "page": options.page_index, "button": options.button_index, "button_cmd": options.button_cmd}
-
-            case "set_keys":
-                if options.button_keys is None:
-                    print("error: --keys not set...")
-                    return
-                if options.button_index is None:
-                    print("error: --button not set...")
-                    return
-                data = {"command": "set_button_keys", "deck": options.deck_index, "page": options.page_index, "button": options.button_index, "button_keys": options.button_keys}
-
-            case "set_icon":
-                if options.icon_path is None:
-                    print("error: --icon not set...")
-                    return
-                if options.button_index is None:
-                    print("error: --button not set...")
-                    return
-                data = {"command": "set_button_icon", "deck": options.deck_index, "page": options.page_index, "button": options.button_index, "icon": options.icon_path}
-
-            case "clear_icon":
-                if options.button_index is None:
-                    print("error: --button not set...")
-                    return
-                data = {"command": "clear_button_icon", "deck": options.deck_index, "page": options.page_index, "button": options.button_index}
+        action_name = options.action.lower()
+        if action_name == "set_page":
+            if options.page_index is None:
+                print("error: --page not set...")
+                return
+            data = {"command": "set_page", "deck": options.deck_index, "page": options.page_index}
+        elif action_name == "set_brightness":
+            if options.brightness is None:
+                print("error: --brightness not set...")
+                return
+            data = {"command": "set_brightness", "deck": options.deck_index, "value": options.brightness}
+        elif action_name == "set_text":
+            if options.button_text is None:
+                print("error: --text not set...")
+                return
+            if options.button_index is None:
+                print("error: --button not set...")
+                return
+            data = {"command": "set_button_text", "deck": options.deck_index, "page": options.page_index, "button": options.button_index, "text": options.button_text}
+        elif action_name == "set_write":
+            if options.button_write is None:
+                print("error: --write not set...")
+                return
+            if options.button_index is None:
+                print("error: --button not set...")
+                return
+            data = {"command": "set_button_write", "deck": options.deck_index, "page": options.page_index, "button": options.button_index, "write": options.button_write}
+        elif action_name == "set_alignment":
+            if options.button_text_alignment is None:
+                print("error: --alignment not set...")
+                return
+            if options.button_index is None:
+                print("error: --button not set...")
+                return
+            data = {"command": "set_alignment", "deck": options.deck_index, "page": options.page_index, "button": options.button_index, "alignment": options.button_text_alignment}
+        elif action_name == "set_cmd":
+            if options.button_cmd is None:
+                print("error: --command not set...")
+                return
+            if options.button_index is None:
+                print("error: --button not set...")
+                return
+            data = {"command": "set_button_cmd", "deck": options.deck_index, "page": options.page_index, "button": options.button_index, "button_cmd": options.button_cmd}
+        elif action_name == "set_keys":
+            if options.button_keys is None:
+                print("error: --keys not set...")
+                return
+            if options.button_index is None:
+                print("error: --button not set...")
+                return
+            data = {"command": "set_button_keys", "deck": options.deck_index, "page": options.page_index, "button": options.button_index, "button_keys": options.button_keys}
+        elif action_name == "set_icon":
+            if options.icon_path is None:
+                print("error: --icon not set...")
+                return
+            if options.button_index is None:
+                print("error: --button not set...")
+                return
+            data = {"command": "set_button_icon", "deck": options.deck_index, "page": options.page_index, "button": options.button_index, "icon": options.icon_path}
+        elif action_name == "clear_icon":
+            if options.button_index is None:
+                print("error: --button not set...")
+                return
+            data = {"command": "clear_button_icon", "deck": options.deck_index, "page": options.page_index, "button": options.button_index}
 
     if data is not None:
         write_json(sock, data)

--- a/streamdeck_ui/cli/server.py
+++ b/streamdeck_ui/cli/server.py
@@ -1,5 +1,6 @@
 import os
 import sys
+import optparse
 import json
 import socket
 from threading import Event, Thread
@@ -72,3 +73,20 @@ class CLIStreamDeckServer:
             os.remove("/tmp/streamdeck_ui.sock")
         except OSError:
             pass
+        
+def execute():
+    parser = optparse.OptionParser()
+    parser.add_option("-p", "--page", type="int", dest="page_index", help="change to specified page (indice is from 1)", metavar="INDEX")
+    (options, args) = parser.parse_args(sys.argv)
+    sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+    sock.connect("/tmp/streamdeck_ui.sock")
+    data = None
+    if(hasattr(options, "page_index")):
+        data = {
+            "command": "page_change",
+            "page": options.page_index
+        }
+    
+    if data is not None:
+        write_json(sock, data)
+

--- a/streamdeck_ui/gui.py
+++ b/streamdeck_ui/gui.py
@@ -19,6 +19,7 @@ from streamdeck_ui.config import LOGO, STATE_FILE
 from streamdeck_ui.semaphore import Semaphore, SemaphoreAcquireError
 from streamdeck_ui.ui_main import Ui_MainWindow
 from streamdeck_ui.ui_settings import Ui_SettingsDialog
+from streamdeck_ui.cli.server import CLIStreamDeckServer
 
 pnput_supported: bool = True
 try:
@@ -874,6 +875,9 @@ def start(_exit: bool = False) -> None:
 
             api.start()
 
+            cli = CLIStreamDeckServer(api, ui)
+            cli.start()
+
             # Configure signal hanlders
             # https://stackoverflow.com/a/4939113/192815
             timer = QTimer()
@@ -895,6 +899,7 @@ def start(_exit: bool = False) -> None:
             else:
                 app.exec()
                 api.stop()
+                cli.stop()
                 sys.exit()
 
     except SemaphoreAcquireError:

--- a/streamdeck_ui/gui.py
+++ b/streamdeck_ui/gui.py
@@ -15,11 +15,11 @@ from PySide6.QtGui import QAction, QDesktopServices, QDrag, QIcon
 from PySide6.QtWidgets import QApplication, QDialog, QFileDialog, QMainWindow, QMenu, QMessageBox, QSizePolicy, QSystemTrayIcon
 
 from streamdeck_ui.api import StreamDeckServer
+from streamdeck_ui.cli.server import CLIStreamDeckServer
 from streamdeck_ui.config import LOGO, STATE_FILE
 from streamdeck_ui.semaphore import Semaphore, SemaphoreAcquireError
 from streamdeck_ui.ui_main import Ui_MainWindow
 from streamdeck_ui.ui_settings import Ui_SettingsDialog
-from streamdeck_ui.cli.server import CLIStreamDeckServer
 
 pnput_supported: bool = True
 try:

--- a/tests/cli/test_commands.py
+++ b/tests/cli/test_commands.py
@@ -1,0 +1,218 @@
+from unittest.mock import MagicMock
+
+from streamdeck_ui.cli import commands
+
+
+def test_set_page():
+    cfg = {
+        "command": "set_page",
+        "deck": 0,
+        "page": 0,
+    }
+    cmd = commands.create_command(cfg)
+
+    assert isinstance(cmd, commands.SetPageCommand)
+    assert cmd.deck_index == 0
+    assert cmd.page_index == 0
+
+    api = MagicMock()
+    ui = MagicMock()
+
+    cmd.execute(api, ui)
+
+    api.set_page.assert_called_once_with(0, 0)
+
+
+def test_set_brightness():
+    cfg = {
+        "command": "set_brightness",
+        "deck": 0,
+        "value": 0,
+    }
+    cmd = commands.create_command(cfg)
+
+    assert isinstance(cmd, commands.SetBrightnessCommand)
+    assert cmd.deck_index == 0
+    assert cmd.brightness == 0
+
+    api = MagicMock()
+    ui = MagicMock()
+
+    cmd.execute(api, ui)
+
+    api.set_brightness.assert_called_once_with(0, 0)
+
+
+def test_set_button_text():
+    cfg = {
+        "command": "set_text",
+        "deck": 0,
+        "page": 0,
+        "button": 0,
+        "text": "test",
+    }
+    cmd = commands.create_command(cfg)
+
+    assert isinstance(cmd, commands.SetButtonTextCommand)
+    assert cmd.deck_index == 0
+    assert cmd.page_index == 0
+    assert cmd.button_index == 0
+    assert cmd.button_text == "test"
+
+    api = MagicMock()
+    ui = MagicMock()
+
+    cmd.execute(api, ui)
+
+    api.set_button_text.assert_called_once_with(0, 0, 0, "test")
+
+
+def test_set_button_write():
+    cfg = {
+        "command": "set_write",
+        "deck": 0,
+        "page": 0,
+        "button": 0,
+        "write": "test",
+    }
+    cmd = commands.create_command(cfg)
+
+    assert isinstance(cmd, commands.SetButtonWriteCommand)
+    assert cmd.deck_index == 0
+    assert cmd.page_index == 0
+    assert cmd.button_index == 0
+    assert cmd.button_write == "test"
+
+    api = MagicMock()
+    ui = MagicMock()
+
+    cmd.execute(api, ui)
+
+    api.set_button_write.assert_called_once_with(0, 0, 0, "test")
+
+
+def test_set_alignment():
+    cfg = {
+        "command": "set_alignment",
+        "deck": 0,
+        "page": 0,
+        "button": 0,
+        "alignment": "test",
+    }
+    cmd = commands.create_command(cfg)
+
+    assert isinstance(cmd, commands.SetButtonTextAlignmentCommand)
+    assert cmd.deck_index == 0
+    assert cmd.page_index == 0
+    assert cmd.button_index == 0
+    assert cmd.button_text_alignment == "test"
+
+    api = MagicMock()
+    ui = MagicMock()
+
+    cmd.execute(api, ui)
+
+    api.set_text_vertical_align.assert_called_once_with(0, 0, 0, "test")
+
+
+def test_set_button_cmd():
+    cfg = {
+        "command": "set_cmd",
+        "deck": 0,
+        "page": 0,
+        "button": 0,
+        "button_cmd": "test",
+    }
+    cmd = commands.create_command(cfg)
+
+    assert isinstance(cmd, commands.SetButtonCmdCommand)
+    assert cmd.deck_index == 0
+    assert cmd.page_index == 0
+    assert cmd.button_index == 0
+    assert cmd.button_cmd == "test"
+
+    api = MagicMock()
+    ui = MagicMock()
+
+    cmd.execute(api, ui)
+
+    api.set_button_command.assert_called_once_with(0, 0, 0, "test")
+
+
+def test_set_button_keys():
+    cfg = {
+        "command": "set_keys",
+        "deck": 0,
+        "page": 0,
+        "button": 0,
+        "button_keys": "test",
+    }
+    cmd = commands.create_command(cfg)
+
+    assert isinstance(cmd, commands.SetButtonKeysCommand)
+    assert cmd.deck_index == 0
+    assert cmd.page_index == 0
+    assert cmd.button_index == 0
+    assert cmd.button_keys == "test"
+
+    api = MagicMock()
+    ui = MagicMock()
+
+    cmd.execute(api, ui)
+
+    api.set_button_keys.assert_called_once_with(0, 0, 0, "test")
+
+
+def test_set_button_icon():
+    cfg = {
+        "command": "set_icon",
+        "deck": 0,
+        "page": 0,
+        "button": 0,
+        "icon": "test",
+    }
+    cmd = commands.create_command(cfg)
+
+    assert isinstance(cmd, commands.SetButtonIconCommand)
+    assert cmd.deck_index == 0
+    assert cmd.page_index == 0
+    assert cmd.button_index == 0
+    assert cmd.icon_path == "test"
+
+    api = MagicMock()
+    ui = MagicMock()
+
+    cmd.execute(api, ui)
+
+    api.set_button_icon.assert_called_once_with(0, 0, 0, "test")
+
+
+def test_clear_button_icon():
+    cfg = {
+        "command": "clear_icon",
+        "deck": 0,
+        "page": 0,
+        "button": 0,
+    }
+    cmd = commands.create_command(cfg)
+
+    assert isinstance(cmd, commands.ClearButtonIconCommand)
+    assert cmd.deck_index == 0
+    assert cmd.page_index == 0
+    assert cmd.button_index == 0
+
+    api = MagicMock()
+    ui = MagicMock()
+
+    cmd.execute(api, ui)
+
+    api.set_button_icon.assert_called_once_with(0, 0, 0, "")
+
+
+def test_unknown_command():
+    cfg = {
+        "command": "unknown",
+    }
+    cmd = commands.create_command(cfg)
+
+    assert cmd is None


### PR DESCRIPTION
Hi, thanks for this useful software! 

I am submitting a Pull Request to add a new feature to your project. This feature allows for controlling a device called StreamDeck through the terminal.

At this point, the feature only allows for transitioning StreamDeck pages.  I have added the ability to navigate to a specific page within the StreamDeck-UI using the `--page` or `-p` option, followed by the page index.

For example, the command `streamdeckc --page 1` will navigate to the second page of the StreamDeck-UI.

To send commands to the StreamDeck-UI, the feature uses a Unix domain socket located at /tmp/streamdeck-ui.sock. I have tested the code and it appears to be working correctly. 

While I believe they will be beneficial to users, I understand that any changes to a project's codebase can be cause for concern. If there are any concerns you have regarding the changes I have made, please let me know and I would be happy to discuss them with you. I am committed to ensuring that the changes I have made are in the best interest of the project and its users.

I would be grateful for your review.

---

Closes #299 